### PR TITLE
fixed not responding thread; commented crashing code out

### DIFF
--- a/pilot/control/monitor.py
+++ b/pilot/control/monitor.py
@@ -17,11 +17,11 @@ logger = logging.getLogger(__name__)
 
 
 def control(queues, traces, args):
-
     while not args.graceful_stop.is_set():
-        time.sleep(30 * 60)
         run_checks(args)
         send_heartbeat()
+        for i in range(1800):
+            args.graceful_stop.wait(1)
 
 
 def check_local_space_limit():
@@ -34,8 +34,8 @@ def check_output_file_sizes():
 
 
 def run_checks(args):
-    if not check_local_space_limit():
-        return args.graceful_stop.set()
+    #if not check_local_space_limit():
+        #return args.graceful_stop.set()
 
     if not check_output_file_sizes():
         return args.graceful_stop.set()

--- a/pilot/control/monitor.py
+++ b/pilot/control/monitor.py
@@ -7,7 +7,6 @@
 # Authors:
 # - Daniel Drizhuk, d.drizhuk@gmail.com, 2017
 
-import time
 import logging
 import os
 from pilot.util.disk import disk_usage
@@ -34,8 +33,8 @@ def check_output_file_sizes():
 
 
 def run_checks(args):
-    #if not check_local_space_limit():
-        #return args.graceful_stop.set()
+    # if not check_local_space_limit():
+        # return args.graceful_stop.set()
 
     if not check_output_file_sizes():
         return args.graceful_stop.set()


### PR DESCRIPTION
Wasnt able to shutdown pilot anymore because this thread sleeps 30 minutes.
I excluded check_local_space_limit() for now because it raises the following exception:
Exception in thread Thread-5:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/threading.py", line 811, in __bootstrap_inner
    self.run()
  File "/usr/lib64/python2.7/threading.py", line 764, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/data/pilot2/pilot/control/monitor.py", line 24, in control
    run_checks(args)
  File "/data/pilot2/pilot/control/monitor.py", line 38, in run_checks
    if not check_local_space_limit():
  File "/data/pilot2/pilot/control/monitor.py", line 30, in check_local_space_limit
    return du[2] < human2bytes(config.Python.free_space_limit)
  File "/data/pilot2/pilot/util/config.py", line 87, in __getattr__
    return object.__getattribute__(self, item)
AttributeError: 'instance' object has no attribute 'Python'
