### PR TITLE
Small fixes

### DIFF
--- a/pilot/control/job.py
+++ b/pilot/control/job.py
@@ -198,8 +198,8 @@ def validate(queues, traces, args):
                 os.symlink('../pilotlog.txt', os.path.join(job_dir, 'pilotlog.txt'))
             except Exception as e:
                 log.debug('cannot symlink pilot log: %s' % str(e))
-                #queues.failed_jobs.put(job)
-                #break
+#                queues.failed_jobs.put(job)
+#                break
 
             queues.validated_jobs.put(job)
         else:

--- a/pilot/control/job.py
+++ b/pilot/control/job.py
@@ -198,11 +198,12 @@ def validate(queues, traces, args):
                 os.symlink('../pilotlog.txt', os.path.join(job_dir, 'pilotlog.txt'))
             except Exception as e:
                 log.debug('cannot symlink pilot log: %s' % str(e))
-                queues.failed_jobs.put(job)
-                break
+                #queues.failed_jobs.put(job)
+                #break
 
             queues.validated_jobs.put(job)
         else:
+            log.debug('Failed to validate job=%s' % job['PandaID'])
             queues.failed_jobs.put(job)
 
 

--- a/pilot/util/disk.py
+++ b/pilot/util/disk.py
@@ -22,8 +22,8 @@ if hasattr(os, 'statvfs'):  # POSIX
 
 else:
     def disk_usage(path):
-        return _ntuple_diskusage(0,0,0)
-    #raise NotImplementedError("platform not supported")
+        return _ntuple_diskusage(0, 0, 0)
+#    raise NotImplementedError("platform not supported")
 
 disk_usage.__doc__ = """
 Return disk usage statistics about the given path as a (total, used, free)

--- a/pilot/util/disk.py
+++ b/pilot/util/disk.py
@@ -21,7 +21,9 @@ if hasattr(os, 'statvfs'):  # POSIX
         return _ntuple_diskusage(total, used, free)
 
 else:
-    raise NotImplementedError("platform not supported")
+    def disk_usage(path):
+        return _ntuple_diskusage(0,0,0)
+    #raise NotImplementedError("platform not supported")
 
 disk_usage.__doc__ = """
 Return disk usage statistics about the given path as a (total, used, free)

--- a/pilot/util/https.py
+++ b/pilot/util/https.py
@@ -167,7 +167,7 @@ def request(url, data=None, plain=False):
         req = 'curl -sS --compressed --connect-timeout %s --max-time %s '\
               '--capath %s --cert %s --cacert %s --key %s '\
               '-H %s %s %s' % (100, 120,
-                               pipes.quote(_ctx.capath), pipes.quote(_ctx.cacert), pipes.quote(_ctx.cacert), pipes.quote(_ctx.cacert),
+                               pipes.quote(_ctx.capath or ''), pipes.quote(_ctx.cacert or ''), pipes.quote(_ctx.cacert or ''), pipes.quote(_ctx.cacert or ''),
                                pipes.quote('User-Agent: %s' % _ctx.user_agent),
                                "-H " + pipes.quote('Accept: application/json') if not plain else '',
                                pipes.quote(url + '?' + urllib.urlencode(data) if data else ''))

--- a/pilot/util/workernode.py
+++ b/pilot/util/workernode.py
@@ -83,8 +83,13 @@ def get_node_name():
 
     :return: node name (string)
     """
+    if hasattr(os, 'uname'):
+        host = os.uname()[1]
+    else:
+        import socket
+        host = socket.gethostname()
 
-    return get_condor_node_name(os.uname()[1])
+    return get_condor_node_name(host)
 
 
 def get_condor_node_name(nodename):


### PR DESCRIPTION
Small fixes required to run pilot in dev/test environment:

  - https: avoid uncontrolled exception if user has no VOMS proxy initialized
  - workernode.get_node_name(): failover to socket.gethostname for non UNIX platform
  - job.validate(): consider creating symlink for the pilotlog.txt as non fatal error
  - disk.disk_usage(): add stub implementation for non UNIX platforms