### PR TITLE
pilot.info queuedata updates

### DIFF
--- a/pilot/info/basedata.py
+++ b/pilot/info/basedata.py
@@ -74,13 +74,24 @@ class BaseData(object):
                 ## cast to required type and apply default validation
                 hvalidator = validators.get(ktype, validators.get(None))
                 if callable(hvalidator):
-                    value = hvalidator(raw, ktype, kname)
+                    value = hvalidator(raw, ktype, kname, defval=getattr(self, kname, None))
                 ## apply custom validation if defined
                 hvalidator = getattr(self, 'clean__%s' % kname, None)
                 if callable(hvalidator):
                     value = hvalidator(raw, value)
 
                 setattr(self, kname, value)
+
+        self.clean()
+
+    def clean(self):
+        """
+            Validate and finally clean up required data values (required object properties) if need
+            Executed once all fields have already passed field-specific validation checks
+            Could be customized by child object
+            :return: None
+        """
+        pass
 
     ##
     ## default validators

--- a/pilot/info/configinfo.py
+++ b/pilot/info/configinfo.py
@@ -47,6 +47,7 @@ class PilotConfigProvider(object):
         data = {'maxwdir': 10555,  # in MB
                 'maxwdir_broken': self.config.Pilot.maximum_input_file_sizes,  # ## Config API is broken -- FIX me later
                 #'container_type': 'singularity:pilot;docker:wrapper',  # ## for testing
+                'es_stageout_gap': 601,  # in seconds, for testing: FIXME LATER
                 }
 
         logger.info('queuedata: following keys will be overwritten by config values: %s' % data)

--- a/pilot/info/queuedata.py
+++ b/pilot/info/queuedata.py
@@ -52,9 +52,15 @@ class QueueData(BaseData):
     maxwdir = 0    # in MB
 
     timefloor = 0  # The maximum time during which the pilot is allowed to start a new job, in seconds
+    corecount = 1  #
+
+    pledgedcpu = 0  #
+    zip_time_gap = 0  # time gap value in seconds
+    es_stageout_gap = 0  ## time gap value in seconds for ES stageout
 
     # specify the type of attributes for proper data validation and casting
-    _keys = {int: ['timefloor', 'maxwdir'],
+    _keys = {int: ['timefloor', 'maxwdir', 'pledgedcpu', 'es_stageout_gap', 'zip_time_gap',
+                   'corecount'],
              str: ['name', 'appdir', 'catchall', 'cmtconfig', 'container_options', 'container_type',
                    'state', 'site'],
              dict: ['copytools', 'acopytools', 'astorages', 'aprotocols'],
@@ -93,6 +99,17 @@ class QueueData(BaseData):
         }
 
         self._load_data(data, kmap)
+
+    def clean(self):
+        """
+            Validate and finally clean up required data values (required object properties) if need
+            :return: None
+        """
+        # validate es_stageout_gap value
+        if not self.es_stageout_gap:
+            is_opportunistic = self.pledgedcpu and self.pledgedcpu == -1
+            self.es_stageout_gap = 600 if is_opportunistic else 7200  ## 10 munites for opportunistic or 5 hours for normal resources
+        pass
 
     ## custom function pattern to apply extra validation to the key values
     ##def clean__keyname(self, raw, value):


### PR DESCRIPTION
updates for pilot.info data containers:
  - added final validation handler `clean` to check/clean-up required fields at the step when all custom field-specific validation passed
 - use field value defined in class level as a default

QueueData updates: 
 - added new fields (corecount, pledgedcpu, zip_time_gap, es_stageout_gap)

**Notes (TO BE CLARIFIED):**

I introduced new field `es_stageout_gap` - which is considered as `zip_time_gap` for ES workflow, if in general `zip_time_gap` is only applied/relevant to ES, than this new field looks redundant, otherwise can we invent proper names for it, like `stageout_gap` for normal jobs and `es_stageout_gap` for ES?
