### PR TITLE
Job class implementation based on pilot.info

### DIFF
--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -260,7 +260,7 @@ def copytool_in(queues, traces, args):
 
             send_state(job, args, 'running')
 
-            logger.info('Test job.infosys: queuedata.copytools=%s' % job['infosys'].queuedata.copytools)
+            logger.info('Test job.infosys: queuedata.copytools=%s' % job.infosys.queuedata.copytools)
 
             if _stage_in(args, job):
                 queues.finished_data_in.put(job)

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -102,7 +102,7 @@ def _stage_in(args, job):
                   '--no-subdir',
                   '--rse', job['ddmEndPointIn'],
                   '%s:%s' % (job['scopeIn'], job['inFiles'])],
-                 cwd=job['working_dir'],
+                 cwd=job.workdir,
                  logger=log):
         return False
     return True
@@ -295,26 +295,26 @@ def copytool_out(queues, traces, args):
 
 
 def prepare_log(job, tarball_name):
-    log = logger.getChild(str(job['PandaID']))
+    log = logger.getChild(job.jobid)
     log.info('preparing log file')
 
     input_files = job['inFiles'].split(',')
     output_files = job['outFiles'].split(',')
     force_exclude = ['geomDB', 'sqlite200']
 
-    with tarfile.open(name=os.path.join(job['working_dir'], job['logFile']),
+    with tarfile.open(name=os.path.join(job.workdir, job['logFile']),
                       mode='w:gz',
                       dereference=True) as log_tar:
-        for _file in list(set(os.listdir(job['working_dir'])) - set(input_files) - set(output_files) - set(force_exclude)):
-            if os.path.exists(os.path.join(job['working_dir'], _file)):
+        for _file in list(set(os.listdir(job.workdir)) - set(input_files) - set(output_files) - set(force_exclude)):
+            if os.path.exists(os.path.join(job.workdir, _file)):
                 logging.debug('adding to log: %s' % _file)
-                log_tar.add(os.path.join(job['working_dir'], _file),
+                log_tar.add(os.path.join(job.workdir, _file),
                             arcname=os.path.join(tarball_name, _file))
 
     return {'scope': job['scopeLog'],
             'name': job['logFile'],
             'guid': job['logGUID'],
-            'bytes': os.stat(os.path.join(job['working_dir'], job['logFile'])).st_size}
+            'bytes': os.stat(os.path.join(job.workdir, job['logFile'])).st_size}
 
 
 def _stage_out(args, outfile, job):
@@ -334,7 +334,7 @@ def _stage_out(args, outfile, job):
                                    bufsize=-1,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE,
-                                   cwd=job['working_dir'])
+                                   cwd=job.workdir)
     except Exception as e:
         log.error('could not execute: %s' % str(e))
         return None
@@ -373,7 +373,7 @@ def _stage_out(args, outfile, job):
         return None
 
     summary = None
-    path = os.path.join(job['working_dir'], 'rucio_upload.json')
+    path = os.path.join(job.workdir, 'rucio_upload.json')
     if not os.path.exists(path):
         log.warning('no such file: %s' % path)
         return None

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -93,7 +93,7 @@ def _call(args, executable, cwd=os.getcwd(), logger=logger):
 
 
 def _stage_in(args, job):
-    log = logger.getChild(str(job['PandaID']))
+    log = logger.getChild(job.jobid)
 
     os.environ['RUCIO_LOGGING_FORMAT'] = '{0}%(asctime)s %(levelname)s [%(message)s]'
     if not _call(args,
@@ -318,7 +318,7 @@ def prepare_log(job, tarball_name):
 
 
 def _stage_out(args, outfile, job):
-    log = logger.getChild(str(job['PandaID']))
+    log = logger.getChild(job.jobid)
 
     os.environ['RUCIO_LOGGING_FORMAT'] = '%(asctime)s %(levelname)s [%(message)s]'
     executable = ['/usr/bin/env',
@@ -393,7 +393,7 @@ def _stage_out_all(job, args):
     :return:
     """
 
-    log = logger.getChild(str(job['PandaID']))
+    log = logger.getChild(job.jobid)
     outputs = {}
 
     if job['stageout'] == 'log':
@@ -409,7 +409,7 @@ def _stage_out_all(job, args):
         else:
             log.warning('Job object does not contain a job report (payload failed?) - will only stage-out log file')
     outputs['%s:%s' % (job['scopeLog'], job['logFile'])] = prepare_log(job, 'tarball_PandaJob_%s_%s' %
-                                                                       (job['PandaID'], args.queue))
+                                                                       (job.jobid, args.queue))
 
     fileinfodict = {}
     failed = False
@@ -475,11 +475,11 @@ def queue_monitoring(queues, traces, args):
             # stage-out log file then add the job to the failed_jobs queue
             job['stageout'] = "log"
             if not _stage_out_all(job, args):
-                logger.info("job %d failed during stage-in and stage-out of log, adding job object to failed_data_outs "
-                            "queue" % job['PandaID'])
+                logger.info("job %s failed during stage-in and stage-out of log, adding job object to failed_data_outs "
+                            "queue" % job.jobid)
                 queues.failed_data_out.put(job)
             else:
-                logger.info("job %d failed during stage-in, adding job object to failed_jobs queue" % job['PandaID'])
+                logger.info("job %s failed during stage-in, adding job object to failed_jobs queue" % job.jobid)
                 queues.failed_jobs.put(job)
 
         # monitor the finished_data_out queue
@@ -507,5 +507,5 @@ def queue_monitoring(queues, traces, args):
         except Queue.Empty:
             pass
         else:
-            logger.info("job %d failed during stage-out, adding job object to failed_jobs queue" % job['PandaID'])
+            logger.info("job %s failed during stage-out, adding job object to failed_jobs queue" % job.jobid)
             queues.failed_jobs.put(job)

--- a/pilot/control/job.py
+++ b/pilot/control/job.py
@@ -188,7 +188,7 @@ def validate(queues, traces, args):
             job_dir = os.path.join(args.mainworkdir, 'PanDA_Pilot-%s' % job.jobid)
             try:
                 os.mkdir(job_dir)
-                job['working_dir'] = job_dir
+                job.workdir = job_dir
             except Exception as e:
                 log.debug('cannot create working directory: %s' % str(e))
                 queues.failed_jobs.put(job)

--- a/pilot/control/job.py
+++ b/pilot/control/job.py
@@ -650,23 +650,20 @@ def job_has_finished(queues):
     :return: True is the payload has finished or failed
     """
 
-    try:
-        panda_id = int(os.environ.get('PandaID', 0))
-    except TypeError:
-        panda_id = 0
+    jobid = os.environ.get('PandaID')
 
     # is there anything in the finished_jobs queue?
     finished_queue_snapshot = list(queues.finished_jobs.queue)
-    peek = [s_job for s_job in finished_queue_snapshot if panda_id == s_job.jobid]
-    if len(peek) != 0:
-        logger.info("job %d has completed (finished)" % panda_id)
+    peek = [obj for obj in finished_queue_snapshot if jobid == obj.jobid]
+    if peek:
+        logger.info("job %s has completed (finished)" % jobid)
         return True
 
     # is there anything in the failed_jobs queue?
     failed_queue_snapshot = list(queues.failed_jobs.queue)
-    peek = [s_job for s_job in failed_queue_snapshot if panda_id == s_job.jobid]
-    if len(peek) != 0:
-        logger.info("job %d has completed (failed)" % panda_id)
+    peek = [obj for obj in failed_queue_snapshot if jobid == obj.jobid]
+    if peek:
+        logger.info("job %s has completed (failed)" % jobid)
         return True
 
     return False

--- a/pilot/control/payload.py
+++ b/pilot/control/payload.py
@@ -139,12 +139,12 @@ def execute_payloads(queues, traces, args):
                     time.sleep(0.1)
                 continue
 
-            out = open(os.path.join(job['working_dir'], 'payload.stdout'), 'wb')
-            err = open(os.path.join(job['working_dir'], 'payload.stderr'), 'wb')
+            out = open(os.path.join(job.workdir, 'payload.stdout'), 'wb')
+            err = open(os.path.join(job.workdir, 'payload.stderr'), 'wb')
 
             send_state(job, args, 'starting')
 
-            if job.get('eventService', '').lower() == "true":
+            if job.is_eventservice:
                 payload_executor = eventservice.Executor(args, job, out, err)
             else:
                 payload_executor = generic.Executor(args, job, out, err)
@@ -184,7 +184,7 @@ def process_job_report(job):
     """
 
     log = logger.getChild(str(job['PandaID']))
-    path = os.path.join(job['working_dir'], config.Payload.jobreport)
+    path = os.path.join(job.workdir, config.Payload.jobreport)
     if not os.path.exists(path):
         log.warning('job report does not exist: %s' % path)
     else:

--- a/pilot/control/payload.py
+++ b/pilot/control/payload.py
@@ -127,10 +127,10 @@ def execute_payloads(queues, traces, args):
     while not args.graceful_stop.is_set():
         try:
             job = queues.validated_payloads.get(block=True, timeout=1)
-            log = logger.getChild(str(job['PandaID']))
+            log = logger.getChild(job.jobid)
 
             q_snapshot = list(queues.finished_data_in.queue)
-            peek = [s_job for s_job in q_snapshot if job['PandaID'] == s_job['PandaID']]
+            peek = [s_job for s_job in q_snapshot if job.jobid == s_job.jobid]
             if len(peek) == 0:
                 queues.validated_payloads.put(job)
                 for i in xrange(10):
@@ -183,7 +183,7 @@ def process_job_report(job):
     :return:
     """
 
-    log = logger.getChild(str(job['PandaID']))
+    log = logger.getChild(job.jobid)
     path = os.path.join(job.workdir, config.Payload.jobreport)
     if not os.path.exists(path):
         log.warning('job report does not exist: %s' % path)
@@ -232,7 +232,7 @@ def validate_post(queues, traces, args):
             job = queues.finished_payloads.get(block=True, timeout=1)
         except Queue.Empty:
             continue
-        log = logger.getChild(str(job['PandaID']))
+        log = logger.getChild(job.jobid)
 
         # process the job report if it exists and set multiple fields
         process_job_report(job)
@@ -257,7 +257,7 @@ def failed_post(queues, traces, args):
             job = queues.failed_payloads.get(block=True, timeout=1)
         except Queue.Empty:
             continue
-        log = logger.getChild(str(job['PandaID']))
+        log = logger.getChild(job.jobid)
 
         log.debug('adding log for log stageout')
 

--- a/pilot/control/payloads/eventservice.py
+++ b/pilot/control/payloads/eventservice.py
@@ -40,7 +40,7 @@ class Executor(generic.Executor, ESHook):
                   None if no available events.
         """
         job = self.get_job()
-        log = logger.getChild(str(job['PandaID']))
+        log = logger.getChild(job.jobid)
         log.info("Getting event ranges: (num_ranges: %s)" % num_ranges)
         if len(self.__event_ranges) < num_ranges:
             ret = download_event_ranges(job, num_ranges=infosys.queuedata.corecount)
@@ -107,7 +107,7 @@ class Executor(generic.Executor, ESHook):
                         Fro 'failed' event ranges, it's {'id': <id>, 'status': 'failed', 'message': <full message>}.
         """
         job = self.get_job()
-        log = logger.getChild(str(job['PandaID']))
+        log = logger.getChild(job.jobid)
         log.info("Handling out message: %s" % message)
 
         self.__all_out_messages.append(message)
@@ -124,7 +124,7 @@ class Executor(generic.Executor, ESHook):
         :return: out_messages, output_file, fsize, adler32
         """
         job = self.get_job()
-        log = logger.getChild(str(job['PandaID']))
+        log = logger.getChild(job.jobid)
 
         out_messages = []
         while len(self.__queued_out_messages) > 0:
@@ -177,7 +177,7 @@ class Executor(generic.Executor, ESHook):
         if len(self.__queued_out_messages):
             if force or self.__last_stageout_time is None or (time.time() > self.__last_stageout_time + infosys.queuedata.es_stageout_gap):
                 job = self.get_job()
-                log = logger.getChild(str(job['PandaID']))
+                log = logger.getChild(job.jobid)
 
                 out_messagess, output_file, fsize, adler32 = self.tarzip_output_es()
                 log.info("tar/zip event ranges: %s, output_file: %s, fsize: %s, adler32: %s" % (out_messagess, output_file, fsize, adler32))
@@ -202,7 +202,7 @@ class Executor(generic.Executor, ESHook):
         Clean temp produced files
         """
         job = self.get_job()
-        log = logger.getChild(str(job['PandaID']))
+        log = logger.getChild(job.jobid)
 
         for msg in self.__all_out_messages:
             if msg['status'] in ['failed', 'fatal']:
@@ -227,7 +227,7 @@ class Executor(generic.Executor, ESHook):
         :param err:
         :return:
         """
-        log = logger.getChild(str(job['PandaID']))
+        log = logger.getChild(job.jobid)
 
         # get the payload command from the user specific code
         # cmd = get_payload_command(job, queuedata)
@@ -270,7 +270,7 @@ class Executor(generic.Executor, ESHook):
         :return:
         """
 
-        log = logger.getChild(str(job['PandaID']))
+        log = logger.getChild(job.jobid)
 
         breaker = False
         exit_code = None

--- a/pilot/control/payloads/eventservice.py
+++ b/pilot/control/payloads/eventservice.py
@@ -241,7 +241,7 @@ class Executor(generic.Executor, ESHook):
         log.debug('executable=%s' % executable)
 
         try:
-            payload = {'executable': executable, 'workdir': job['working_dir'], 'output_file': out, 'error_file': err}
+            payload = {'executable': executable, 'workdir': job.workdir, 'output_file': out, 'error_file': err}
             log.debug("payload: %s" % payload)
 
             log.info("Starting ESProcess")

--- a/pilot/control/payloads/generic.py
+++ b/pilot/control/payloads/generic.py
@@ -83,11 +83,11 @@ class Executor(object):
             #                         bufsize=-1,
             #                         stdout=out,
             #                         stderr=err,
-            #                         cwd=job['working_dir'],
+            #                         cwd=job.workdir,
             #                         shell=True)
 
-            proc = execute(cmd, platform=job.platform, workdir=job['working_dir'], returnproc=True,
-                           usecontainer=True, stdout=out, stderr=err, cwd=job['working_dir'], job=job)
+            proc = execute(cmd, platform=job.platform, workdir=job.workdir, returnproc=True,
+                           usecontainer=True, stdout=out, stderr=err, cwd=job.workdir, job=job)
         except Exception as e:
             log.error('could not execute: %s' % str(e))
             return None

--- a/pilot/control/payloads/generic.py
+++ b/pilot/control/payloads/generic.py
@@ -45,13 +45,13 @@ class Executor(object):
         :param err:
         :return:
         """
-        # log = logger.getChild(str(job['PandaID']))
+        # log = logger.getChild(job.jobid)
 
         # try:
         # create symbolic link for sqlite200 and geomDB in job dir
         #    for db_name in ['sqlite200', 'geomDB']:
         #         src = '/cvmfs/atlas.cern.ch/repo/sw/database/DBRelease/current/%s' % db_name
-        #         link_name = 'job-%s/%s' % (job['PandaID'], db_name)
+        #         link_name = 'job-%s/%s' % (job.jobid, db_name)
         #         os.symlink(src, link_name)
         # except Exception as e:
         #     log.error('could not create symbolic links to database files: %s' % e)
@@ -69,7 +69,7 @@ class Executor(object):
         :return: proc (subprocess returned by Popen())
         """
 
-        log = logger.getChild(str(job['PandaID']))
+        log = logger.getChild(job.jobid)
 
         # get the payload command from the user specific code
         pilot_user = os.environ.get('PILOT_USER', 'generic').lower()
@@ -106,7 +106,7 @@ class Executor(object):
         :return:
         """
 
-        log = logger.getChild(str(job['PandaID']))
+        log = logger.getChild(job.jobid)
 
         breaker = False
         exit_code = None
@@ -144,7 +144,7 @@ class Executor(object):
 
         :return:
         """
-        log = logger.getChild(str(self.__job['PandaID']))
+        log = logger.getChild(str(self.__job.jobid))
 
         exit_code = 1
         if self.setup_payload(self.__job, self.__out, self.__err):

--- a/pilot/control/payloads/generic.py
+++ b/pilot/control/payloads/generic.py
@@ -86,7 +86,7 @@ class Executor(object):
             #                         cwd=job['working_dir'],
             #                         shell=True)
 
-            proc = execute(cmd, platform=job['cmtConfig'], workdir=job['working_dir'], returnproc=True,
+            proc = execute(cmd, platform=job.platform, workdir=job['working_dir'], returnproc=True,
                            usecontainer=True, stdout=out, stderr=err, cwd=job['working_dir'], job=job)
         except Exception as e:
             log.error('could not execute: %s' % str(e))

--- a/pilot/eventservice/eventrange.py
+++ b/pilot/eventservice/eventrange.py
@@ -26,14 +26,14 @@ def download_event_ranges(job, num_ranges=None):
     :return: List of event ranges.
     """
 
-    log = logger.getChild(str(job['PandaID']))
+    log = logger.getChild(job.jobid)
 
     try:
         if not num_ranges:
             # ToBeFix num_ranges with corecount
             num_ranges = 1
 
-        data = {'pandaID': job['PandaID'],
+        data = {'pandaID': job.jobid,
                 'jobsetID': job['jobsetID'],
                 'taskID': job['taskID'],
                 'nRanges': num_ranges}
@@ -57,7 +57,7 @@ def update_event_ranges(job, event_ranges, version=1):
 
     :param event_ranges:
     """
-    log = logger.getChild(str(job['PandaID']))
+    log = logger.getChild(job.jobid)
 
     log.info("Updating event ranges: %s" % event_ranges)
 

--- a/pilot/info/__init__.py
+++ b/pilot/info/__init__.py
@@ -13,6 +13,7 @@ in a unified structured way to all Pilot modules by providing high-level API
 
 from .infoservice import InfoService
 from .jobinfo import JobInfoProvider  # noqa
+from .jobdata import JobData          # noqa
 
 #from .queuedata import QueueData
 

--- a/pilot/info/basedata.py
+++ b/pilot/info/basedata.py
@@ -154,7 +154,7 @@ class BaseData(object):
             logger.warning('failed to convert data for key=%s, raw=%s to type=%s' % (kname, raw, ktype))
             return defval
 
-        return raw.lower() in ['1', 'true', 'yes']
+        return val.lower() in ['1', 'true', 'yes']
 
     def clean_dictdata(self, raw, ktype, kname=None, defval=None):
         """

--- a/pilot/info/jobdata.py
+++ b/pilot/info/jobdata.py
@@ -132,7 +132,7 @@ class JobData(BaseData):
 
         self._load_data(data, kmap)
 
-    def is_analysis(self):
+    def is_analysis(self):  ## if it's experiment specific logic then it could be isolated into extended JobDataATLAS class
         """
             Determine whether the job is an analysis user job or not.
             :return: True in case of user analysis job

--- a/pilot/info/jobdata.py
+++ b/pilot/info/jobdata.py
@@ -127,6 +127,7 @@ class JobData(BaseData):
             'jobparams': 'jobPars',
             'corecount': 'coreCount',
             'platform': 'cmtConfig',
+            'is_eventservice': 'eventService',  ## is it coming from Job def??
         }
 
         self._load_data(data, kmap)

--- a/pilot/info/jobdata.py
+++ b/pilot/info/jobdata.py
@@ -1,0 +1,190 @@
+"""
+The implementation of data structure to host Job definition.
+
+The main reasons for such incapsulation are to
+ - apply in one place all data validation actions (for attributes and values)
+ - introduce internal information schema (names of attribues) to remove dependency
+ with data structrure, formats, names from external source (PanDA)
+
+:author: Alexey Anisenkov
+:contact: anisyonk@cern.ch
+:date: February 2018
+"""
+
+import os
+
+from .basedata import BaseData
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class JobData(BaseData):
+    """
+        High-level object to host Job definition/settings
+    """
+
+    # ## put explicit list of all the attributes with comments for better inline-documentation by Sphinx
+    # ## FIX ME LATER: use proper doc format
+    # ## incomplete list of attributes .. to be extended once becomes used
+
+    jobid = None                # Unique Job  identifier (forced to be a string)
+    taskid = None               # Unique Task identifier, the task that this job belongs to (forced to be a string)
+
+    jobparams = ""         # Job parameters defining the execution of the job
+    transformation = ""    # Script execution name
+
+    state = ""            # Current job state
+    status = ""           # Current job status
+    workdir = ""          # Working directoty for this job
+
+    corecount = 1   # Number of cores as requested by the task
+    platform = ""   # cmtconfig value from the task definition
+
+    is_eventservice = False        # True for event service jobs
+
+    _rawdata = {}  ## RAW data to keep backward compatible behavior for a while ## TO BE REMOVED once all job attributes will be covered
+
+    # specify the type of attributes for proper data validation and casting
+    _keys = {int: ['corecount'],
+             str: ['jobid', 'taskid', 'jobparams', 'transformation',
+                   'state', 'status', 'workdir',
+                   'platform'],
+             dict: [],
+             bool: ['is_eventservice']
+             }
+
+    def __init__(self, data):
+        """
+            :param data: input dictionary of data settings
+        """
+
+        self.infosys = None  # reference to Job specific InfoService instace
+        self._rawdata = data  ###  TEMPORARY CACHE -- REMOVE ME LATER once all fields moved to Job object attributes
+
+        self.load(data)
+
+        # DEBUG
+        import pprint
+        logger.debug('Initialize Job from raw:\n%s' % pprint.pformat(data))
+        #logger.debug('Final parsed Job content:\n%s' % self)
+
+    def __getitem__(self, key):
+        """
+            Temporary Integration function to keep dict-based access for old logic in compatible way
+            TO BE REMOVED ONCE all fields will be moved to Job object attributes
+        """
+
+        if key == 'infosys':
+            return self.infosys
+
+        #if hasattr(self, key):
+        #    return getattr(self, key)
+
+        return self._rawdata[key]
+
+    def __setitem__(self, key, val):
+        """
+            Temporary Integration function to keep dict-based access for old logic in compatible way
+            TO BE REMOVED ONCE all fields will be moved to Job object attributes
+        """
+
+        self._rawdata[key] = val
+
+    def __contains__(self, key):
+        """
+            Temporary Integration function to keep dict-based access for old logic in compatible way
+            TO BE REMOVED ONCE all fields will be moved to Job object attributes
+        """
+
+        return key in self._rawdata
+
+    def get(self, key, defval=None):
+        """
+            Temporary Integration function to keep dict-based access for old logic in compatible way
+            TO BE REMOVED ONCE all fields will be moved to Job object attributes
+        """
+
+        return self._rawdata.get(key, defval)
+
+    def load(self, data):
+        """
+            Construct and initialize data from ext source
+            :param data: input dictionary of job data settings
+        """
+
+        ## the translation map of the container attributes from external data to internal schema
+        ## 'internal_name':('ext_name1', 'extname2_if_any')
+        ## 'internal_name2':'ext_name3'
+
+        ## first defined ext field will be used
+        ## if key is not explicitly specified then ext name will be used as is
+        ## fix me later to proper internal names if need
+
+        kmap = {
+            'jobid': 'PandaID',
+            'taskid': 'taskID',
+            'jobparams': 'jobPars',
+            'corecount': 'coreCount',
+            'platform': 'cmtConfig',
+        }
+
+        self._load_data(data, kmap)
+
+    def is_analysis(self):
+        """
+            Determine whether the job is an analysis user job or not.
+            :return: True in case of user analysis job
+        """
+
+        is_analysis = self.transformation.startswith('https://') or self.transformation.startswith('http://')
+
+        # apply addons checks later if need
+
+        return is_analysis
+
+    def is_build(self):
+        """
+            Determine whether the job is a build job or not.
+            (i.e. check if the job only has one output file that is a lib file)
+            :return: True for a build job
+        """
+
+        return False  ## TO BE IMPLEMENTED
+
+    def clean(self):
+        """
+            Validate and finally clean up required data values (object properties) if need
+            :return: None
+        """
+
+        pass
+
+    ## custom function pattern to apply extra validation to the key values
+    ##def clean__keyname(self, raw, value):
+    ##  :param raw: raw value passed from ext source as input
+    ##  :param value: preliminary cleaned and casted to proper type value
+    ##
+    ##    return value
+
+    def clean__corecount(self, raw, value):
+        """
+            Verify and validate value for the corecount key (set to 1 if not set)
+        """
+
+        # Overwrite the corecount value with ATHENA_PROC_NUMBER if it is set
+        athena_corecount = os.environ.get('ATHENA_PROC_NUMBER')
+        if athena_corecount:
+            try:
+                value = int(athena_corecount)
+            except Exception:
+                logger.info("ATHENA_PROC_NUMBER is not properly set.. ignored, data=%s" % athena_corecount)
+
+        return value if value else 1
+
+    def clean__platform(self, raw, value):
+        """
+            Verify and validate value for the platform key
+        """
+
+        return value if value.lower() not in ['null', 'none'] else ''

--- a/pilot/info/jobinfo.py
+++ b/pilot/info/jobinfo.py
@@ -42,5 +42,20 @@ class JobInfoProvider(object):
             :return: dict of settings for given PandaQueue as a key
         """
 
-        ## TO BE IMPLEMENTED
-        return None
+        # keys format: [(inputkey, outputkey), inputkey2]
+        # outputkey is the name of external source attribute
+        keys = [('platform', 'cmtconfig')]
+
+        data = {}
+        for key in keys:
+            if not isinstance(key, (list, tuple)):
+                key = [key, key]
+            ikey = key[0]
+            okey = key[1] if len(key) > 1 else key[0]
+            val = getattr(self.job, ikey)
+            if val:  # ignore empty or zero values -- FIX ME LATER for integers later if need
+                data[okey] = val
+
+        logger.info('queuedata: following keys will be overwritten by Job values: %s' % data)
+
+        return {pandaqueue: data}

--- a/pilot/info/queuedata.py
+++ b/pilot/info/queuedata.py
@@ -35,7 +35,7 @@ class QueueData(BaseData):
     appdir = ""     #
     catchall = ""   #
 
-    cmtconfig = ""
+    platform = ""     # cmtconfig value
     container_options = ""  # singularity only options? to be reviewed and forced to be a dict (support options for other containers?)
     container_type = {}  # dict of container names by user as a key
 
@@ -61,7 +61,7 @@ class QueueData(BaseData):
     # specify the type of attributes for proper data validation and casting
     _keys = {int: ['timefloor', 'maxwdir', 'pledgedcpu', 'es_stageout_gap',
                    'corecount'],
-             str: ['name', 'appdir', 'catchall', 'cmtconfig', 'container_options', 'container_type',
+             str: ['name', 'appdir', 'catchall', 'platform', 'container_options', 'container_type',
                    'state', 'site'],
              dict: ['copytools', 'acopytools', 'astorages', 'aprotocols'],
              bool: ['direct_access_lan', 'direct_access_wan']
@@ -95,6 +95,7 @@ class QueueData(BaseData):
 
         kmap = {
             'name': 'nickname',
+            'platform': 'cmtconfig',
             'site': ('atlas_site', 'gstat'),
             'es_stageout_gap': 'zip_time_gap',
         }

--- a/pilot/user/atlas/common.py
+++ b/pilot/user/atlas/common.py
@@ -10,7 +10,7 @@
 import os
 
 # from pilot.common.exception import PilotException
-from pilot.user.atlas.setup import should_pilot_prepare_asetup, is_user_analysis_job, get_asetup, \
+from pilot.user.atlas.setup import should_pilot_prepare_asetup, get_asetup, \
     get_asetup_options, is_standard_atlas_job
 
 import logging
@@ -30,7 +30,7 @@ def get_payload_command(job):
     prepareasetup = should_pilot_prepare_asetup(job.get('noExecStrCnv', None), job['jobPars'])
 
     # Is it a user job or not?
-    userjob = is_user_analysis_job(job['transformation'])
+    userjob = job.is_analysis()
 
     # Get the platform value
     platform = job.infosys.queuedata.platform

--- a/pilot/user/atlas/common.py
+++ b/pilot/user/atlas/common.py
@@ -10,7 +10,7 @@
 import os
 
 # from pilot.common.exception import PilotException
-from pilot.user.atlas.setup import should_pilot_prepare_asetup, is_user_analysis_job, get_platform, get_asetup, \
+from pilot.user.atlas.setup import should_pilot_prepare_asetup, is_user_analysis_job, get_asetup, \
     get_asetup_options, is_standard_atlas_job
 
 import logging
@@ -33,7 +33,7 @@ def get_payload_command(job):
     userjob = is_user_analysis_job(job['transformation'])
 
     # Get the platform value
-    platform = get_platform(job['cmtConfig'])
+    platform = job.infosys.queuedata.platform
 
     # Define the setup for asetup, i.e. including full path to asetup and setting of ATLAS_LOCAL_ROOT_BASE
     asetuppath = get_asetup(asetup=prepareasetup)

--- a/pilot/user/atlas/container.py
+++ b/pilot/user/atlas/container.py
@@ -59,7 +59,7 @@ def get_middleware_container():
     pass
 
 
-def extract_container_options():  ## TO BE DEPRECATED: consider job['infosys'].queuedata.container_options
+def extract_container_options():  ## TO BE DEPRECATED: consider job.infosys.queuedata.container_options
     """ Extract any singularity options from catchall """
 
     # e.g. catchall = "somestuff singularity_options=\'-B /etc/grid-security/certificates,/var/spool/slurmd,/cvmfs,/ceph/grid,/data0,/sys/fs/cgroup\'"
@@ -178,7 +178,7 @@ def get_middleware_type():
     return middleware_type
 
 
-def get_container_name(user="pilot"):  ## TO BE DEPRECATED: consider job['infosys'].queuedata.container_type.get("pilot")
+def get_container_name(user="pilot"):  ## TO BE DEPRECATED: consider job.infosys.queuedata.container_type.get("pilot")
     """
     Return the container name
     E.g. container_type = 'singularity:pilot;docker:wrapper'
@@ -223,7 +223,7 @@ def singularity_wrapper(cmd, platform, workdir, job):
 
     # Should a container be used?
     #container_name = get_container_name()
-    container_name = job['infosys'].queuedata.container_type.get("pilot")  # resolve container name for user=pilot
+    container_name = job.infosys.queuedata.container_type.get("pilot")  # resolve container name for user=pilot
     logger.debug("resolved container_name from job.infosys.queuedata.contaner_type: %s" % container_name)
 
     if container_name == 'singularity':
@@ -231,7 +231,7 @@ def singularity_wrapper(cmd, platform, workdir, job):
 
         # Get the singularity options
         #singularity_options = extract_container_options()
-        singularity_options = job['infosys'].queuedata.container_options
+        singularity_options = job.infosys.queuedata.container_options
         logger.debug("resolved singularity_options from job.infosys.queuedata.container_options: %s" % singularity_options)
 
         if not singularity_options:

--- a/pilot/user/atlas/setup.py
+++ b/pilot/user/atlas/setup.py
@@ -54,7 +54,7 @@ def should_pilot_prepare_asetup(noexecstrcnv, jobpars):
     return prepareasetup
 
 
-def is_user_analysis_job(trf):
+def is_user_analysis_job(trf):  ## DEPRECATED: consider job.is_analysis()
     """
     Determine whether the job is an analysis job or not.
     The trf name begins with a protocol for user analysis jobs.

--- a/pilot/user/atlas/setup.py
+++ b/pilot/user/atlas/setup.py
@@ -71,7 +71,7 @@ def is_user_analysis_job(trf):
     return analysisjob
 
 
-def get_platform(jobcmtconfig):
+def get_platform(jobcmtconfig):  ## DEPRECATED: consider job.infosys.queuedata.platform
     """
     Get the platform (cmtconfig) from the job def or schedconfig
 

--- a/pilot/util/information.py
+++ b/pilot/util/information.py
@@ -211,7 +211,7 @@ def get_appdir():
     return get_field_value('appdir')
 
 
-def get_catchall():  ## TO BE DEPRECATED: consider job['infosys'].queuedata.catchall
+def get_catchall():  ## TO BE DEPRECATED: consider job.infosys.queuedata.catchall
     """
     Return the catchall field value from the schedconfig queuedata.
 
@@ -231,7 +231,7 @@ def get_cmtconfig():
     return get_field_value('cmtconfig')
 
 
-def get_container_options():  ## TO BE DEPRECATED: consider job['infosys'].queuedata.container_options
+def get_container_options():  ## TO BE DEPRECATED: consider job.infosys.queuedata.container_options
     """
     Return the container_options field value from the schedconfig queuedata.
 
@@ -244,7 +244,7 @@ def get_container_options():  ## TO BE DEPRECATED: consider job['infosys'].queue
     return container_options
 
 
-def get_container_type():  ## TO BE DEPRECATED: consider job['infosys'].queuedata.container_type
+def get_container_type():  ## TO BE DEPRECATED: consider job.infosys.queuedata.container_type
     """
     Return the container_type field value from the schedconfig queuedata.
 


### PR DESCRIPTION
Initial Job class implementation (JobData) based on `pilot.info` data container:

 - added few object fields as an example (jobid, taskid, jobparams, transformation, corecount, platform)
 - kept backward compatible dict-based behavior  (to be removed once migrated)
 - updated control/job workflow to expose new Job object
 
The Job class will be upgraded later with full list of functionality.

Updated somewhere logic to consider new `JobData` structure:
 - migrated: `job['PandaID']` -> `job.jobid` 
 - migrated: `job['working_dir']` -> `job.workdir`
 - migrated: `job['infosys']` -> `job.infosys`
 - replaced  wrapper `is_user_analysis_job()` -> job.is_analysis()

plus other updates for `QueueData` and `pilot.info`

regards,
Alexey