### PR TITLE
HPC workflow

### DIFF
--- a/doc/components/index.rst
+++ b/doc/components/index.rst
@@ -8,7 +8,7 @@
 
     Authors:
      - Daniel Drizhuk, d.drizhuk@gmail.com, 2017
-     - Paul Nilsson, paul.nilsson@cern.ch, 2017
+     - Paul Nilsson, paul.nilsson@cern.ch, 2017-2018
 
 Components
 ==========
@@ -22,6 +22,7 @@ Components
     copytool/index
     eventservice/index
     info/index
+    resource/index
     user/index
     util/index
     workflow/index

--- a/doc/components/resource/generic.rst
+++ b/doc/components/resource/generic.rst
@@ -1,0 +1,19 @@
+..
+    Pilot 2 pilot.resource.generic doc file
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Authors:
+     - Paul Nilsson, paul.nilsson@cern.ch, 2018
+
+generic
+=======
+
+.. automodule:: pilot.resource.generic
+    :members:
+    :private-members:
+    :special-members:
+    :undoc-members:

--- a/doc/components/resource/index.rst
+++ b/doc/components/resource/index.rst
@@ -1,0 +1,19 @@
+..
+    Pilot 2 documentation pilot.resource index
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Authors:
+     - Paul Nilsson, paul.nilsson@cern.ch, 2018
+
+resource components
+===================
+
+.. toctree::
+    :maxdepth: 2
+
+    generic
+    titan

--- a/doc/components/resource/titan.rst
+++ b/doc/components/resource/titan.rst
@@ -1,0 +1,19 @@
+..
+    Pilot 2 pilot.resource.titan doc file
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Authors:
+     - Paul Nilsson, paul.nilsson@cern.ch, 2018
+
+titan
+=====
+
+.. automodule:: pilot.resource.titan
+    :members:
+    :private-members:
+    :special-members:
+    :undoc-members:

--- a/pilot.py
+++ b/pilot.py
@@ -329,8 +329,6 @@ if __name__ == '__main__':
         else:
             logging.info("removed %s" % mainworkdir)
 
-    logging.shutdown()
-
     # in Harvester mode, create a kill_worker file that will instruct Harvester that the pilot has finished
     if args.harvester:
         from pilot.util.harvester import kill_worker
@@ -338,20 +336,22 @@ if __name__ == '__main__':
 
     if not trace:
         logging.critical('pilot startup did not succeed -- aborting')
-        sys.exit(FAILURE)
+        exit_code = FAILURE
     elif trace.pilot['nr_jobs'] > 0:
         if trace.pilot['nr_jobs'] == 1:
             logging.getLogger(__name__).info('pilot has finished (%d job was processed)' % trace.pilot['nr_jobs'])
         else:
             logging.getLogger(__name__).info('pilot has finished (%d jobs were processed)' % trace.pilot['nr_jobs'])
-        sys.exit(SUCCESS)
+        exit_code = SUCCESS
     elif trace.pilot['state'] == FAILURE:
         logging.critical('pilot workflow failure -- aborting')
-        sys.exit(FAILURE)
+        exit_code = FAILURE
     elif trace.pilot['state'] == ERRNO_NOJOBS:
         logging.critical('pilot did not process any events -- aborting')
-        #logging.getLogger(__name__).critical('pilot did not process any events -- aborting')
-        sys.exit(ERRNO_NOJOBS)
+        exit_code = ERRNO_NOJOBS
     else:
         logging.info('pilot has finished')
-        sys.exit(0)
+        exit_code = SUCCESS
+
+    logging.shutdown()
+    sys.exit(exit_code)

--- a/pilot.py
+++ b/pilot.py
@@ -337,15 +337,20 @@ if __name__ == '__main__':
         kill_worker()
 
     if not trace:
-        logging.getLogger(__name__).critical('pilot startup did not succeed -- aborting')
+        logging.critical('pilot startup did not succeed -- aborting')
         sys.exit(FAILURE)
     elif trace.pilot['nr_jobs'] > 0:
+        if trace.pilot['nr_jobs'] == 1:
+            logging.getLogger(__name__).info('pilot has finished (%d job was processed)' % trace.pilot['nr_jobs'])
+        else:
+            logging.getLogger(__name__).info('pilot has finished (%d jobs were processed)' % trace.pilot['nr_jobs'])
         sys.exit(SUCCESS)
     elif trace.pilot['state'] == FAILURE:
-        logging.getLogger(__name__).critical('pilot workflow failure -- aborting')
+        logging.critical('pilot workflow failure -- aborting')
         sys.exit(FAILURE)
     elif trace.pilot['state'] == ERRNO_NOJOBS:
-        logging.getLogger(__name__).critical('pilot did not process any events -- aborting')
+        logging.critical('pilot did not process any events -- aborting')
+        #logging.getLogger(__name__).critical('pilot did not process any events -- aborting')
         sys.exit(ERRNO_NOJOBS)
     else:
         logging.getLogger(__name__).info('pilot has finished')

--- a/pilot.py
+++ b/pilot.py
@@ -25,7 +25,7 @@ from pilot.util.filehandling import get_pilot_work_dir, create_pilot_work_dir
 from pilot.util.config import config
 from pilot.util.harvester import is_harvester_mode
 
-VERSION = '2018-03-08.003'
+VERSION = '2018-03-08.004'
 
 
 def main():

--- a/pilot.py
+++ b/pilot.py
@@ -344,6 +344,9 @@ if __name__ == '__main__':
     elif trace.pilot['state'] == FAILURE:
         logging.getLogger(__name__).critical('pilot workflow failure -- aborting')
         sys.exit(FAILURE)
-    else:
+    elif trace.pilot['state'] == ERRNO_NOJOBS:
         logging.getLogger(__name__).critical('pilot did not process any events -- aborting')
         sys.exit(ERRNO_NOJOBS)
+    else:
+        logging.getLogger(__name__).info('pilot has finished')
+        sys.exit(0)

--- a/pilot.py
+++ b/pilot.py
@@ -337,13 +337,13 @@ if __name__ == '__main__':
         kill_worker()
 
     if not trace:
-        logging.getLogger(__name__).fatal('pilot startup did not succeed -- aborting')
+        logging.getLogger(__name__).critical('pilot startup did not succeed -- aborting')
         sys.exit(FAILURE)
     elif trace.pilot['nr_jobs'] > 0:
         sys.exit(SUCCESS)
     elif trace.pilot['state'] == FAILURE:
-        logging.getLogger(__name__).fatal('pilot workflow failure -- aborting')
+        logging.getLogger(__name__).critical('pilot workflow failure -- aborting')
         sys.exit(FAILURE)
     else:
-        logging.getLogger(__name__).fatal('pilot did not process any events -- aborting')
+        logging.getLogger(__name__).critical('pilot did not process any events -- aborting')
         sys.exit(ERRNO_NOJOBS)

--- a/pilot.py
+++ b/pilot.py
@@ -25,7 +25,7 @@ from pilot.util.filehandling import get_pilot_work_dir, create_pilot_work_dir
 from pilot.util.config import config
 from pilot.util.harvester import is_harvester_mode
 
-VERSION = '2018-03-08.004'
+VERSION = '2018-03-09.001'
 
 
 def main():

--- a/pilot.py
+++ b/pilot.py
@@ -94,7 +94,8 @@ def import_module(**kwargs):
                            '--allow-same-user': kwargs.get('allow_same_user', 'True'),
                            '--pilot-user': kwargs.get('pilot_user', 'generic'),
                            '--input-dir': kwargs.get('input_dir', ''),
-                           '--output-dir': kwargs.get('output_dir', '')
+                           '--output-dir': kwargs.get('output_dir', ''),
+                           '--hpc-resource': kwargs.get('hpc_resource', '')
                            }
 
     args = Args()

--- a/pilot.py
+++ b/pilot.py
@@ -337,13 +337,13 @@ if __name__ == '__main__':
         kill_worker()
 
     if not trace:
-        logging.getLogger(__name__).critical('pilot startup did not succeed -- aborting')
+        logging.getLogger(__name__).fatal('pilot startup did not succeed -- aborting')
         sys.exit(FAILURE)
     elif trace.pilot['nr_jobs'] > 0:
         sys.exit(SUCCESS)
     elif trace.pilot['state'] == FAILURE:
-        logging.getLogger(__name__).critical('pilot workflow failure -- aborting')
+        logging.getLogger(__name__).fatal('pilot workflow failure -- aborting')
         sys.exit(FAILURE)
     else:
-        logging.getLogger(__name__).critical('pilot did not process any events -- aborting')
+        logging.getLogger(__name__).fatal('pilot did not process any events -- aborting')
         sys.exit(ERRNO_NOJOBS)

--- a/pilot.py
+++ b/pilot.py
@@ -353,5 +353,5 @@ if __name__ == '__main__':
         #logging.getLogger(__name__).critical('pilot did not process any events -- aborting')
         sys.exit(ERRNO_NOJOBS)
     else:
-        logging.getLogger(__name__).info('pilot has finished')
+        logging.info('pilot has finished')
         sys.exit(0)

--- a/pilot.py
+++ b/pilot.py
@@ -265,6 +265,12 @@ if __name__ == '__main__':
                             default='',
                             help='Output directory')
 
+    # HPC options
+    arg_parser.add_argument('--hpc-resource',
+                            dest='hpc_resource',
+                            default='',
+                            help='Name of the HPC (e.g. Titan)')
+
     args = arg_parser.parse_args()
 
     # Define and set the main harvester control boolean

--- a/pilot.py
+++ b/pilot.py
@@ -340,5 +340,9 @@ if __name__ == '__main__':
         sys.exit(FAILURE)
     elif trace.pilot['nr_jobs'] > 0:
         sys.exit(SUCCESS)
+    elif trace.pilot['state'] == FAILURE:
+        logging.getLogger(__name__).critical('pilot workflow failure -- aborting')
+        sys.exit(FAILURE)
     else:
+        logging.getLogger(__name__).critical('pilot did not process any events -- aborting')
         sys.exit(ERRNO_NOJOBS)

--- a/pilot/resource/__init__.py
+++ b/pilot/resource/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Paul Nilsson, paul.nilsson@cern.ch, 2018

--- a/pilot/resource/generic.py
+++ b/pilot/resource/generic.py
@@ -16,7 +16,7 @@ def get_setup(job=None):
     Return the resource specific setup.
 
     :param job: optional job object.
-    :return: setup string.
+    :return: setup commands (list).
     """
 
-    pass
+    return []

--- a/pilot/resource/generic.py
+++ b/pilot/resource/generic.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Paul Nilsson, paul.nilsson@cern.ch, 2018
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def get_setup(job=None):
+    """
+    Return the resource specific setup.
+
+    :param job: optional job object.
+    :return: setup string.
+    """
+
+    pass

--- a/pilot/resource/titan.py
+++ b/pilot/resource/titan.py
@@ -16,7 +16,26 @@ def get_setup(job=None):
     Return the resource specific setup.
 
     :param job: optional job object.
-    :return: setup string.
+    :return: setup commands (list).
     """
 
-    pass
+    setup_commands = ['source /lustre/atlas/proj-shared/csc108/app_dir/pilot/grid_env/external/setup.sh',
+                      'source $MODULESHOME/init/bash',
+                      'tmp_dirname=/tmp/scratch',
+                      'tmp_dirname+="/tmp"',
+                      'export TEMP=$tmp_dirname',
+                      'export TMPDIR=$TEMP',
+                      'export TMP=$TEMP',
+                      'export LD_LIBRARY_PATH=/ccs/proj/csc108/AtlasReleases/ldpatch:$LD_LIBRARY_PATH',
+                      'export ATHENA_PROC_NUMBER=16',
+                      'export G4ATLAS_SKIPFILEPEEK=1',
+                      'export PANDA_RESOURCE=\"ORNL_Titan_MCORE\"',
+                      'export ROOT_TTREECACHE_SIZE=1',
+                      'export RUCIO_APPID=\"simul\"',
+                      'export RUCIO_ACCOUNT=\"pilot\"',
+                      'export CORAL_DBLOOKUP_PATH=/ccs/proj/csc108/AtlasReleases/21.0.15/nfs_db_files',
+                      'export CORAL_AUTH_PATH=$SW_INSTALL_AREA/DBRelease/current/XMLConfig',
+                      'export DATAPATH=$SW_INSTALL_AREA/DBRelease/current:$DATAPATH',
+                      ' ']
+
+    return setup_commands

--- a/pilot/resource/titan.py
+++ b/pilot/resource/titan.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Paul Nilsson, paul.nilsson@cern.ch, 2018
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def get_setup(job=None):
+    """
+    Return the resource specific setup.
+
+    :param job: optional job object.
+    :return: setup string.
+    """
+
+    pass

--- a/pilot/user/atlas/common.py
+++ b/pilot/user/atlas/common.py
@@ -197,7 +197,7 @@ def parse_jobreport_data(job_report):
                 work_attributes['nInputFiles'] = len(job_report['files']['input']['subfiles'])
 
     workdir_size = get_workdir_size()
-    work_attributes['jobMetrics'] = 'core_count=%s n_events=%s db_time=%s db_data=%s workdir_size=%s' % \
+    work_attributes['jobMetrics'] = 'coreCount=%s nEvents=%s dbTime=%s dbData=%s workDirSize=%s' % \
                                     (core_count,
                                         work_attributes["n_events"],
                                         work_attributes["__db_time"],

--- a/pilot/workflow/generic.py
+++ b/pilot/workflow/generic.py
@@ -35,11 +35,11 @@ def run(args):
 
     The function sets up the internal queues which handle the flow of jobs.
 
-    :param args: arguments.
+    :param args: pilot arguments.
     :returns: traces.
     """
 
-    logger.info('setting up signal')
+    logger.info('setting up signal handling')
     signal.signal(signal.SIGINT, functools.partial(interrupt, args))
 
     logger.info('setting up queues')

--- a/pilot/workflow/generic_hpc.py
+++ b/pilot/workflow/generic_hpc.py
@@ -12,7 +12,10 @@ import functools
 import signal
 from collections import namedtuple
 
-# from pilot.control import job, payload, data, lifetime, monitor
+# from pilot.util.harvester import get_initial_work_report, publish_work_report
+# from pilot.util.auxiliary import time_stamp
+# from pilot.util.filehandling import tar_files, remove, remove_empty_directories
+
 from pilot.util.constants import SUCCESS, FAILURE
 
 import logging
@@ -50,6 +53,13 @@ def run(args):
 
     # example usage:
     logger.info('setup for resource %s: %s' % (args.hpc_resource, str(resource.get_setup())))
+
+    # extract user specific info from job report
+    user = __import__('pilot.user.%s.common' % args.pilot_user, globals(), locals(), [args.pilot_user], -1)
+    # example usage:
+    # user.remove_redundant_files()
+    # user.cleanup_payload()
+    # parse_jobreport_data()
 
     # implement main function here
     # ..

--- a/pilot/workflow/generic_hpc.py
+++ b/pilot/workflow/generic_hpc.py
@@ -45,7 +45,11 @@ def run(args):
         traces.pilot['state'] = FAILURE
         return traces
 
-    logger.info('hpc resource: %s' % args.hpc_resource)
+    # get the resource reference
+    resource = __import__('pilot.resource.%s' % args.hpc_resource, globals(), locals(), [args.hpc_resource], -1)
+
+    # example usage:
+    logger.info('setup for resource %s: %s' % (args.hpc_resource, str(resource.get_setup())))
 
     # implement main function here
     # ..

--- a/pilot/workflow/generic_hpc.py
+++ b/pilot/workflow/generic_hpc.py
@@ -55,7 +55,8 @@ def run(args):
     logger.info('setup for resource %s: %s' % (args.hpc_resource, str(resource.get_setup())))
 
     # extract user specific info from job report
-    user = __import__('pilot.user.%s.common' % args.pilot_user, globals(), locals(), [args.pilot_user], -1)
+    user = __import__('pilot.user.%s.common' % args.pilot_user.lower(), globals(), locals(),
+                      [args.pilot_user.lower()], -1)
     # example usage:
     # user.remove_redundant_files()
     # user.cleanup_payload()

--- a/pilot/workflow/generic_hpc.py
+++ b/pilot/workflow/generic_hpc.py
@@ -6,11 +6,40 @@
 #
 # Authors:
 # - Mario Lassnig, mario.lassnig@cern.ch, 2016
+# - Paul Nilsson, paul.nilsson@cern.ch, 2018
+
+import signal
+from collections import namedtuple
+
+# from pilot.control import job, payload, data, lifetime, monitor
+from pilot.util.constants import SUCCESS
 
 import logging
 logger = logging.getLogger(__name__)
 
 
-def run():
-    logger.critical('not implemented')
-    return -1
+def interrupt(args, signum, frame):
+    logger.info('caught signal: %s' % [v for v, k in signal.__dict__.iteritems() if k == signum][0])
+    args.graceful_stop.set()
+
+
+def run(args):
+    """
+     Main execution function for the generic HPC workflow.
+
+     :param args: pilot arguments.
+     :returns: traces.
+     """
+
+    logger.info('setting up signal handling')
+    signal.signal(signal.SIGINT, functools.partial(interrupt, args))
+
+    logger.info('setting up tracing')
+    traces = namedtuple('traces', ['pilot'])
+    traces.pilot = {'state': SUCCESS,
+                    'nr_jobs': 0}
+
+    # implement main function here
+    # ..
+
+    return traces

--- a/pilot/workflow/generic_hpc.py
+++ b/pilot/workflow/generic_hpc.py
@@ -8,11 +8,12 @@
 # - Mario Lassnig, mario.lassnig@cern.ch, 2016
 # - Paul Nilsson, paul.nilsson@cern.ch, 2018
 
+import functools
 import signal
 from collections import namedtuple
 
 # from pilot.control import job, payload, data, lifetime, monitor
-from pilot.util.constants import SUCCESS
+from pilot.util.constants import SUCCESS, FAILURE
 
 import logging
 logger = logging.getLogger(__name__)
@@ -38,6 +39,13 @@ def run(args):
     traces = namedtuple('traces', ['pilot'])
     traces.pilot = {'state': SUCCESS,
                     'nr_jobs': 0}
+
+    if args.hpc_resource == '':
+        logger.critical('hpc resource not specified, cannot continue')
+        traces.pilot['state'] = FAILURE
+        return traces
+
+    logger.info('hpc resource: %s' % args.hpc_resource)
 
     # implement main function here
     # ..


### PR DESCRIPTION
* Added generic HPC workflow and resource modules. Pilot option --hpc-resource _resource_ (and corresponding pilot 2 wrapper option -x  _resource_) can be used to specify the resource (e.g. titan). The HPC workflow can be selected with the existing pilot option -w generic_hpc. This will select the corresponding pilot.workflow.generic_hpc module which currently has some preliminary code that pulls in some of the functions (as examples) that were migrated from the HPC Pilot developed by D. Oleynik. See the code for more info. The resource specific code is available in the pilot.resource directory (currently some initial code exists for _titan_ and _generic_, specifically the get_setup() function).Note: this workflow is separate from the standard generic pilot workflow, which means that it currently does not provide any of the normal pilot functionalities.
* Added documentation scripts for new HPC code.
* Cleaned up end-of-pilot (previously logging was shutdown prematurely and error constants were not used consistently).
* Corrected jobMetrics fields (requested by D. Oleynik).