### PR TITLE
Pilot info: FileSpec implementation

### DIFF
--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -143,18 +143,21 @@ def _stage_in(args, job):
 
     os.environ['RUCIO_LOGGING_FORMAT'] = '{0}%(asctime)s %(levelname)s [%(message)s]'
 
-    executable = ['/usr/bin/env',
-                  'rucio', '-v', 'download',
-                  '--no-subdir',
-                  '--rse', job.ddmendpointin,
-                  '%s:%s' % (job.scopein, job.infiles)]  # notice the bug here, infiles might be a ,-separated str
+    for fspec in job.indata:
 
-    if not _call(args,
-                 executable,
-                 job,
-                 cwd=job.workdir,
-                 logger=log):
-        return False
+        executable = ['/usr/bin/env',
+                      'rucio', '-v', 'download',
+                      '--no-subdir',
+                      '--rse', fspec.ddmendpoint,
+                      '%s:%s' % (fspec.scope, fspec.lfn)]
+
+        if not _call(args,
+                     executable,
+                     job,
+                     cwd=job.workdir,
+                     logger=log):
+            return False
+
     return True
 
 
@@ -344,12 +347,12 @@ def copytool_out(queues, traces, args):
             continue
 
 
-def prepare_log(job, tarball_name):
+def prepare_log(job, logfile, tarball_name):
     log = logger.getChild(job.jobid)
     log.info('preparing log file')
 
-    input_files = job.infiles.split(',')
-    output_files = job.outfiles.split(',')
+    input_files = [e.lfn for e in job.indata]
+    output_files = [e.lfn for e in job.outdata]
     force_exclude = ['geomDB', 'sqlite200']
 
     # perform special cleanup (user specific) prior to log file creation
@@ -357,7 +360,7 @@ def prepare_log(job, tarball_name):
     user = __import__('pilot.user.%s.common' % pilot_user, globals(), locals(), [pilot_user], -1)
     user.remove_redundant_files(job.workdir)
 
-    with tarfile.open(name=os.path.join(job.workdir, job.logfile),
+    with tarfile.open(name=os.path.join(job.workdir, logfile.lfn),
                       mode='w:gz',
                       dereference=True) as log_tar:
         for _file in list(set(os.listdir(job.workdir)) - set(input_files) - set(output_files) - set(force_exclude)):
@@ -366,10 +369,10 @@ def prepare_log(job, tarball_name):
                 log_tar.add(os.path.join(job.workdir, _file),
                             arcname=os.path.join(tarball_name, _file))
 
-    return {'scope': job.scopelog,
-            'name': job.logfile,
-            'guid': job.logguid,
-            'bytes': os.stat(os.path.join(job.workdir, job.logfile)).st_size}
+    return {'scope': logfile.scope,
+            'name': logfile.lfn,
+            'guid': logfile.guid,
+            'bytes': os.stat(os.path.join(job.workdir, logfile.lfn)).st_size}
 
 
 def _stage_out(args, outfile, job):
@@ -498,9 +501,12 @@ def _stage_out_all(job, args):
             log.warning('transfer of output file(s) failed')
 
     # proceed with log transfer
-    outputs['%s:%s' % (job.scopelog, job.logfile)] = prepare_log(job, 'tarball_PandaJob_%s_%s' %
-                                                                 (job.jobid, args.queue))
-    status = single_stage_out(args, job, outputs['%s:%s' % (job.scopelog, job.logfile)], fileinfodict)
+    # consider only 1st available log file
+    logfile = job.logdata[0]
+    key = '%s:%s' % (logfile.scope, logfile.lfn)
+    outputs[key] = prepare_log(job, logfile, 'tarball_PandaJob_%s_%s' % (job.jobid, args.queue))
+
+    status = single_stage_out(args, job, outputs[key], fileinfodict)
     if not status:
         failed = True
         log.warning('log transfer failed')

--- a/pilot/info/basedata.py
+++ b/pilot/info/basedata.py
@@ -38,7 +38,7 @@ class BaseData(object):
         """
             Construct and initialize data from ext source.
 
-            :param data: input dictionary of queue data settings
+            :param data: input dictionary of raw data settings
             :param kmap: the translation map of data attributes from external format to internal schema
             :param validators: map of validation handlers to be applied
         """
@@ -177,6 +177,27 @@ class BaseData(object):
 
         elif raw is None:
             return defval
+        try:
+            return ktype(raw)
+        except Exception:
+            logger.warning('failed to convert data for key=%s, raw=%s to type=%s' % (kname, raw, ktype))
+            return defval
+
+    def clean_listdata(self, raw, ktype, kname=None, defval=None):
+        """
+            Clean and convert input value to requested list type
+            :param raw: raw input data
+            :param ktype: variable type to which result should be casted
+            :param defval: default value to be used in case of cast error
+        """
+
+        if isinstance(raw, ktype):
+            return raw
+
+        elif raw is None:
+            return defval
+        elif isinstance(raw, basestring):
+            raw = raw.split(',')
         try:
             return ktype(raw)
         except Exception:

--- a/pilot/info/filespec.py
+++ b/pilot/info/filespec.py
@@ -37,8 +37,8 @@ class FileSpec(BaseData):
     guid = ""
 
     filesize = 0
-    checksum = ""
-    scope = ""  # file scope
+    checksum = {}    # file checksum values, allowed keys=['adler32', 'md5'], e.g. `fspec.checksum.get('adler32')`
+    scope = ""       # file scope
 
     dataset = ""
     ddmendpoint = ""    ## DDMEndpoint name (input or output depending on FileSpec.type)
@@ -76,8 +76,8 @@ class FileSpec(BaseData):
         self.load(data)
 
         if True:  # DEBUG
-            import pprint
-            logger.debug('initialize FileSpec from raw:\n%s' % pprint.pformat(data))
+            #import pprint
+            #logger.debug('initialize FileSpec from raw:\n%s' % pprint.pformat(data))
             logger.debug('Final parsed FileSpec content:\n%s' % self)
 
     def load(self, data):
@@ -87,14 +87,10 @@ class FileSpec(BaseData):
         """
 
         # the translation map of the key attributes from external data to internal schema
-        # first defined ext field name will be used
         # if key is not explicitly specified then ext name will be used as is
-        ## fix me later to proper internal names if need
 
         kmap = {
-            # 'internal_name': ('ext_name1', 'extname2_if_any')
             # 'internal_name2': 'ext_name3'
-
         }
 
         self._load_data(data, kmap)
@@ -105,6 +101,25 @@ class FileSpec(BaseData):
     ##  :param value: preliminary cleaned and casted to proper type value
     ##
     ##    return value
+
+    def clean__checksum(self, raw, value):
+        """
+            Validate value for the checksum key
+            Expected raw format is 'ad:value' or 'md:value'
+        """
+
+        if isinstance(value, dict):
+            return value
+
+        cmap = {'ad': 'adler32', 'md': 'md5'}
+
+        ctype, checksum = 'adler32', value
+        cc = value.split(':')
+        if len(cc) == 2:
+            ctype, checksum = cc
+            ctype = cmap.get(ctype) or 'adler32'
+
+        return {ctype: checksum}
 
     def is_directaccess(self, ensure_replica=True):
         """

--- a/pilot/info/filespec.py
+++ b/pilot/info/filespec.py
@@ -1,0 +1,142 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Alexey Anisenkov, anisyonk@cern.ch, 2018
+
+"""
+The implementation of data structure to host File related data description.
+
+The main reasons for such incapsulation are to
+ - apply in one place all data validation actions (for attributes and values)
+ - introduce internal information schema (names of attribues) to remove direct dependency to ext storage/structures
+
+:author: Alexey Anisenkov
+:date: April 2018
+"""
+
+from .basedata import BaseData
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class FileSpec(BaseData):
+    """
+        High-level object to host File Specification (meta data like lfn, checksum, replica details, etc.)
+    """
+
+    ## put explicit list of all the attributes with comments for better inline-documentation by sphinx
+    ## FIX ME LATER: use proper doc format
+
+    ## incomplete list of attributes .. to be extended once becomes used
+
+    lfn = ""
+    guid = ""
+
+    filesize = 0
+    checksum = ""
+    scope = ""  # file scope
+
+    dataset = ""
+    ddmendpoint = ""    ## DDMEndpoint name (input or output depending on FileSpec.type)
+
+    ## dispatchDblock =  ""       # moved from Pilot1: is it needed? suggest proper internal name?
+    ## dispatchDBlockToken = ""   # moved from Pilot1: is it needed? suggest proper internal name?
+
+    ## prodDBlock = ""           # moved from Pilot1: is it needed? suggest proper internal name?
+    ## storage_token = "" # prodDBlockToken = ""      # moved from Pilot1: suggest proper internal name (storage token?)
+
+    ## local keys
+    type = ''         # type of File: input, output of log
+    replicas = []     # list of resolved input replicas
+    surl = ''         # source url
+    turl = ''         # transfer url
+    mtime = 0         # file modification time
+    status = None     # file transfer status value
+    status_code = 0   # file trsansfer status code
+
+    # specify the type of attributes for proper data validation and casting
+    _keys = {int: ['filesize', 'mtime', 'status_code'],
+             str: ['lfn', 'guid', 'checksum', 'scope', 'dataset', 'ddmendpoint',
+                   'type', 'surl', 'turl', 'status'],
+             list: ['replicas'],
+             bool: []
+             }
+
+    def __init__(self, type='input', **data):  ## FileSpec can be split into FileSpecInput + FileSpecOuput classes in case of significant logic changes
+        """
+            :param kwargs: input dictionary of object description
+            :param type: type of File: either input, output or log
+        """
+
+        self.type = type
+        self.load(data)
+
+        if True:  # DEBUG
+            import pprint
+            logger.debug('initialize FileSpec from raw:\n%s' % pprint.pformat(data))
+            logger.debug('Final parsed FileSpec content:\n%s' % self)
+
+    def load(self, data):
+        """
+            Construct and initialize data from ext source for Input `FileSpec`
+            :param data: input dictionary of object description
+        """
+
+        # the translation map of the key attributes from external data to internal schema
+        # first defined ext field name will be used
+        # if key is not explicitly specified then ext name will be used as is
+        ## fix me later to proper internal names if need
+
+        kmap = {
+            # 'internal_name': ('ext_name1', 'extname2_if_any')
+            # 'internal_name2': 'ext_name3'
+
+        }
+
+        self._load_data(data, kmap)
+
+    ## custom function pattern to apply extra validation to the key values
+    ##def clean__keyname(self, raw, value):
+    ##  :param raw: raw value passed from ext source as input
+    ##  :param value: preliminary cleaned and casted to proper type value
+    ##
+    ##    return value
+
+    def is_directaccess(self, ensure_replica=True):
+        """
+            Check if given (input) file can be used for direct access mode by Job transformation script
+            :param ensure_replica: boolean, if True then check by allowed schemas of file replica turl will be considered as well
+            :return: boolean
+        """
+
+        # check by filename pattern
+        filename = self.lfn.lower()
+
+        is_rootfile = True
+        exclude_pattern = ['.tar.gz', '.lib.tgz', '.raw.']
+        for e in exclude_pattern:
+            if e in filename:
+                is_rootfile = False
+                break
+
+        if not is_rootfile:
+            return False
+
+        is_directaccess = True
+        #is_directaccess = self.prodDBlockToken != 'local'  ## FIX ME LATER once prodDBlockToken (proper name?) will be added into the FileSpec
+
+        if ensure_replica:
+
+            allowed_replica_schemas = ['root://', 'dcache://', 'dcap://', 'file://']
+
+            if self.turl:
+                if True not in set([self.turl.startswith(e) for e in allowed_replica_schemas]):
+                    is_directaccess = False
+            else:
+                is_directaccess = False
+
+        return is_directaccess


### PR DESCRIPTION
pilot info updates (FileSpec):

 - base implementation of FileSpec class (encapsulates File related properties like lfn, dataset, checksum, guid, etc for input, output and log files, support of data validation)
 - added corresponding fields to Job class to host the list of FileSpec entries (job.indata, job.outdata, job.logdata) for input/output/log files

 - as an example, replace old job.{logfile, scopelog, logguid} occurrence with job.logdata FileSpec extraction, job.infiles -> job.indata