### PR TITLE
Infosys: manage custom options from JobParams (--overwriteQueueData, ZIP_MAP)

### DIFF
--- a/pilot/info/basedata.py
+++ b/pilot/info/basedata.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 class BaseData(object):
     """
         High-level object to host structured data collected from external source
-        It's cosidered to be like a bridge (connector) in order to remove direct dependency to
+        It's considered to be like a bridge (connector) in order to remove direct dependency to
         external schema (format) implementation
     """
 

--- a/pilot/info/jobdata.py
+++ b/pilot/info/jobdata.py
@@ -21,6 +21,9 @@ The main reasons for such incapsulation are to
 """
 
 import os
+import ast
+import shlex
+import pipes
 
 from .basedata import BaseData
 from .filespec import FileSpec
@@ -74,6 +77,8 @@ class JobData(BaseData):
     payload = ""  # payload name
     utilities = {}  # utility processes { <name>: [<process handle>, number of launches, command string], .. }
     pid = -1  # payload pid
+
+    overwrite_queuedata = {}  # Custom settings extracted from JobParams (--overwriteQueueData) to be used as master values for `QueueData`
 
     # from job definition
     attemptnr = 0  # job attempt number
@@ -361,3 +366,81 @@ class JobData(BaseData):
         """
 
         return value if value.lower() not in ['null', 'none'] else ''
+
+    def clean__jobparams(self, raw, value):
+        """
+            Verify and validate value for the jobparams key
+            Extract from jobparams non related to Job options
+        """
+
+        ## extract overwrite options
+        options, ret = self.parse_args(value, {'--overwriteQueueData': lambda x: ast.literal_eval(x) if x else {}}, remove=True)
+        self.overwrite_queuedata = options.get('--overwriteQueueData', {})
+
+        logger.debug('Extracted data from jobparams: overwrite_queuedata=%s' % self.overwrite_queuedata)
+
+        return ret
+
+    @classmethod  # noqa: C901
+    def parse_args(self, data, options, remove=False):
+        """
+            Extract option/values from string containing command line options (arguments)
+            :param data: input command line arguments (raw string)
+            :param options: dict of option names to be considered: (name, type), type is a cast function to be applied with result value
+            :param remove: boolean, if True then exclude specified options from returned raw string of command line arguments
+            :return: tuple: (dict of extracted options, raw string of final command line options)
+        """
+
+        logger.debug('Do extract options=%s from data=%s' % (options.keys(), data))
+
+        if not options:
+            return {}, data
+
+        try:
+            args = shlex.split(data)
+        except ValueError, e:
+            logger.error('Failed to parse input arguments from data=%s, error=%s .. skipped.' % (data, e.message))
+            return {}, data
+
+        opts, curopt, pargs = {}, None, []
+        for arg in args:
+            if arg.startswith('-'):
+                if curopt is not None:
+                    opts[curopt] = None
+                    pargs.append([curopt, None])
+                curopt = arg
+                continue
+            if curopt is None:  # no open option, ignore
+                pargs.append(arg)
+            else:
+                opts[curopt] = arg
+                pargs.append([curopt, arg])
+                curopt = None
+        if curopt:
+            pargs.append([curopt, None])
+
+        ret = {}
+        for opt, fcast in options.iteritems():
+            val = opts.get(opt)
+            try:
+                val = fcast(val) if callable(fcast) else val
+            except Exception, e:
+                logger.error('Failed to extract value for option=%s from data=%s: cast function=%s failed, exception=%s .. skipped' % (opt, val, fcast, e))
+                continue
+            ret[opt] = val
+
+        ## serialize parameters back to string
+        rawdata = data
+        if remove:
+            final_args = []
+            for arg in pargs:
+                if isinstance(arg, (tuple, list)):  ## parsed option
+                    if arg[0] not in options:  # exclude considered options
+                        if arg[1] is None:
+                            arg.pop()
+                        final_args.extend(arg)
+                else:
+                    final_args.append(arg)
+            rawdata = " ".join(pipes.quote(e) for e in final_args)
+
+        return ret, rawdata

--- a/pilot/info/jobinfo.py
+++ b/pilot/info/jobinfo.py
@@ -46,7 +46,7 @@ class JobInfoProvider(object):
 
     def resolve_queuedata(self, pandaqueue, **kwargs):
         """
-            Resolve Job specific settings for queue data (overwriteAGISData)
+            Resolve Job specific settings for queue data (overwriteQueueData)
             :return: dict of settings for given PandaQueue as a key
         """
 
@@ -63,6 +63,8 @@ class JobInfoProvider(object):
             val = getattr(self.job, ikey)
             if val:  # ignore empty or zero values -- FIX ME LATER for integers later if need
                 data[okey] = val
+
+        data.update(self.job.overwrite_queuedata)  ## use job.overwrite_queuedata as a master source
 
         logger.info('queuedata: following keys will be overwritten by Job values: %s' % data)
 


### PR DESCRIPTION
Infosys upgrade:

 - implemented Job params validation logic to extract/remove custom options 
 - added  `--overwriteQueueData` option to customize `QueueData` settings coming from job params, `jobinfo` fixed to consider `job.overwrite_queuedata`
 - extract ZIP_MAP values from Job Params and store them in job object (`JobData.zipmap`)

An example of overwrite Queue data format:
`--overwriteQueueData "{'allowfax':False, 'param':20}"`