### PR TITLE
Data API updates, stage-in contol (Movers resolve replicas)

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -17,6 +17,16 @@ from pilot.common.exception import PilotException
 
 
 class StagingClient(object):
+
+    copytool_modules = {'rucio': {'module_name': 'rucio'},
+                        'gfal': {'module_name': 'gfal'},
+                        'gfalcopy': {'module_name': 'gfal'},
+                        'lcgcp': {'module_name': 'lcgcp'},
+                        'dccp': {'module_name': 'dccp'},
+                        'xrdcp': {'module_name': 'xrdcp'},
+                        'mv': {'module_name': 'mv'}
+                        }
+
     def __init__(self, site=None, ddmendpoint=None, copytool_names=None, fallback_copytool='rucio', infosys_instance=None, logger=None):
         """
         StagingClient constructor needs either copytool_names or ddmendpoint specified
@@ -28,10 +38,8 @@ class StagingClient(object):
         :param logger: logging.Logger object to use for loggin (None means no logging)
         :return:
         """
-        super(StagingClient, self).__init__()
 
-        self.copytool_modules = {}
-        self._fill_copytool_modules()
+        super(StagingClient, self).__init__()
 
         if not logger:
             logger = logging.getLogger('%s.%s' % (__name__, 'null'))
@@ -71,16 +79,6 @@ class StagingClient(object):
         self.site = os.environ.get('VO_ATLAS_AGIS_SITE', site)
         if self.site is None and self.copytool_names == ['rucio']:
             raise PilotException('VO_ATLAS_AGIS_SITE not available, must set StageInClient(site=...) parameter')
-
-    def _fill_copytool_modules(self):
-        self.copytool_modules = {'rucio': {'module_name': 'rucio'},
-                                 'gfal': {'module_name': 'gfal'},
-                                 'gfalcopy': {'module_name': 'gfal'},
-                                 'lcgcp': {'module_name': 'lcgcp'},
-                                 'dccp': {'module_name': 'dccp'},
-                                 'xrdcp': {'module_name': 'xrdcp'},
-                                 'mv': {'module_name': 'mv'}
-                                 }
 
     def _try_copytool_for_transfer(self, copytool, files):
         """

--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -9,7 +9,7 @@
 # - Paul Nilsson, paul.nilsson@cern.ch, 2017
 # - Tobias Wegner, tobias.wegner@cern.ch, 2017-2018
 
-import os
+# refactored by Alexey Anisenkov
 import logging
 
 from pilot.info import infosys
@@ -17,6 +17,9 @@ from pilot.common.exception import PilotException
 
 
 class StagingClient(object):
+    """
+        Base Staging Client
+    """
 
     copytool_modules = {'rucio': {'module_name': 'rucio'},
                         'gfal': {'module_name': 'gfal'},
@@ -24,19 +27,18 @@ class StagingClient(object):
                         'lcgcp': {'module_name': 'lcgcp'},
                         'dccp': {'module_name': 'dccp'},
                         'xrdcp': {'module_name': 'xrdcp'},
-                        'mv': {'module_name': 'mv'}
+                        'mv': {'module_name': 'mv'},
+                        'lsm': {'module_name': 'lsm'}
                         }
 
-    def __init__(self, site=None, ddmendpoint=None, copytool_names=None, fallback_copytool='rucio', infosys_instance=None, logger=None):
-        """
-        StagingClient constructor needs either copytool_names or ddmendpoint specified
+    direct_remoteinput_allowed_schemas = ['root']
+    remoteinput_allowed_schemas = ['root', 'gsiftp', 'dcap', 'davs', 'srm']
 
-        :param site: vo site
-        :param ddmendpoint: ddmendpoint where the copytool settings are stored
-        :param copytool_names: name of copytool or list of copytools to use (if this is, given ddmendpoint will be ignored)
-        :param fallback_copytool: name or list of copytools to use if storage settings cannot be retrieved
-        :param logger: logging.Logger object to use for loggin (None means no logging)
-        :return:
+    def __init__(self, infosys_instance=None, acopytools=None, logger=None, default_copytools='rucio'):
+        """
+            :param acopytools: dict of copytool names per activity to be used for transfers. If not specified will be automatically resolved via infosys.
+            :param logger: logging.Logger object to use for logging (None means no logging)
+            :param default_copytools: copytool name(s) to be used in case of unknown activity passed. Accepts either list of names or single string value.
         """
 
         super(StagingClient, self).__init__()
@@ -44,184 +46,329 @@ class StagingClient(object):
         if not logger:
             logger = logging.getLogger('%s.%s' % (__name__, 'null'))
             logger.disabled = True
+
         self.logger = logger
+        self.infosys = infosys_instance or infosys
 
-        if not copytool_names and not ddmendpoint:
-            raise PilotException('Invalid arguments passed to StagingClient.__init__')
+        if isinstance(acopytools, basestring):
+            acopytools = [acopytools] if acopytools else []
 
-        self.infosys = infosys_instance if infosys_instance else infosys
+        self.acopytools = acopytools
+        if not self.acopytools:  # try to get associated copytools from queuedata
+            self.acopytools = (self.infosys.queuedata.acopytools or {}).copy()
+        if not self.acopytools:  ## resolve from queuedata.copytools
+            self.acopytools = dict(default=(self.infosys.queuedata.copytools or {}).keys())
 
-        self.copytool_names = []
-        if not copytool_names:
-            # try to get the copytools from the storage endpoint config
-            try:
-                storage_data = self.infosys.resolve_storage_data(ddmendpoint).get(ddmendpoint)
-                acopytools = storage_data.acopytools.get('read_lan')
-                if acopytools and len(acopytools):
-                    self.copytool_names = acopytools
-            except Exception:
-                logger.warning('Failed to get copytool from storage endpoint configuration. Using fallback.')
-        else:
-            # given copytools are used instead of storage endpoint configured copytools
-            if isinstance(copytool_names, basestring):
-                copytool_names = [copytool_names]
-            self.copytool_names = copytool_names
+        if not self.acopytools:
+            logger.error('Failed to initilize StagingClient: no acopytools options found, acopytools=' % self.acopytools)
+            raise PilotException("Failed to resolve acopytools settings")
 
-        # if we failed getting the copytools, use rucio as default
-        if not len(self.copytool_names):
-            if isinstance(fallback_copytool, basestring):
-                fallback_copytool = [fallback_copytool]
-            self.copytool_names = fallback_copytool
+        if not self.acopytools.get('default'):
+            if isinstance(default_copytools, basestring):
+                default_copytools = [default_copytools] if default_copytools else []
+            self.acopytools['default'] = default_copytools
 
-        logger.debug('Copytool options: %s' % self.copytool_names)
+        logger.info('Configured copytools per activity: acopytools=%s' % self.acopytools)
 
-        # Check validity of specified site - should be refactored into VO-agnostic setup
-        self.site = os.environ.get('VO_ATLAS_AGIS_SITE', site)
-        if self.site is None and self.copytool_names == ['rucio']:
-            raise PilotException('VO_ATLAS_AGIS_SITE not available, must set StageInClient(site=...) parameter')
-
-    def _try_copytool_for_transfer(self, copytool, files):
+    def resolve_replicas(self, files):  # noqa: C901
         """
-        Try to transfer files with given copytool
-        Needs to be implemented by subclasses
-
-        :param copytool: copytool to try
-        :param files: files to transfer
-        :return: output of the given copytool or None on error
+            Populates filespec.replicas for each entry from `files` list
+            :param files: list of `FileSpec` objects
+            fdat.replicas = [(ddmendpoint, replica, ddm_se, ddm_path)]
+            :return: `files`
         """
-        raise NotImplementedError
 
-    def transfer(self, files):
-        logger = self.logger
-        copytool_names = self.copytool_names[::-1]
-        output = None
-        while len(copytool_names) and output is None:
-            copytool = None
-            copytool_name = copytool_names.pop()
-            module_name = self.copytool_modules[copytool_name]['module_name']
-            logger.info('Trying to use copytool %s' % copytool_name)
+        logger = self.logger  ## the function could be static if logger will be moved outside
+
+        xfiles = []
+        ddmconf = self.infosys.resolve_storage_data()
+
+        for fdat in files:
+            ddmdat = ddmconf.get(fdat.ddmendpoint)
+            if not ddmdat:
+                raise Exception("Failed to resolve input ddmendpoint by name=%s (from PanDA), please check configuration. fdat=%s" % (fdat.ddmendpoint, fdat))
+
+            ## skip fdat if need for further workflow (e.g. to properly handle OS ddms)
+
+            fdat.accessmode = 'copy'        ### quick hack to avoid changing logic below for DIRECT access handling  ## REVIEW AND FIX ME LATER
+            fdat.allowRemoteInputs = False  ### quick hack to avoid changing logic below for DIRECT access handling  ## REVIEW AND FIX ME LATER
+
+            fdat.inputddms = self.infosys.queuedata.astorages.get('pr', {})  ## FIX ME LATER: change to proper activity=read_lan
+            xfiles.append(fdat)
+
+        if not xfiles:  # no files for replica look-up
+            return files
+
+        # load replicas from Rucio
+        from rucio.client import Client
+        c = Client()
+
+        ## for the time being until Rucio bug with geo-ip sorting is resolved
+        ## do apply either simple query list_replicas() without geoip sort to resolve LAN replicas in case of directaccesstype=[None, LAN]
+        # otherwise in case of directaccesstype=WAN mode do query geo sorted list_replicas() with location data passed
+
+        bquery = {'schemes': ['srm', 'root', 'davs', 'gsiftp'],
+                  'dids': [dict(scope=e.scope, name=e.lfn) for e in xfiles]}
+
+        allow_remoteinput = True in set(e.allowRemoteInputs for e in xfiles)  ## implement direct access later
+
+        try:
+            query = bquery.copy()
+            if allow_remoteinput:
+                location = self.detect_client_location()
+                if not location:
+                    raise Exception("Failed to get client location for Rucio")
+                query.update(sort='geoip', client_location=location)
+
             try:
-                copytool = __import__('pilot.copytool.%s' % module_name,
-                                      globals(), locals(),
-                                      [module_name], -1)
-            except Exception as error:
-                logger.warning('Failed to import copytool %s' % module_name)
-                logger.debug('Error: %s' % error)
+                logger.info('Call rucio.list_replicas() with query=%s' % query)
+                replicas = c.list_replicas(**query)
+            except TypeError, e:
+                if query == bquery:
+                    raise
+                logger.warning("Detected outdated Rucio list_replicas(), cannot do geoip-sorting: %s .. fallback to old list_replicas() call" % e)
+                replicas = c.list_replicas(**bquery)
+
+        except Exception, e:
+            raise PilotException("Failed to get replicas from Rucio: %s" % e)  #, code=PilotErrors.ERR_FAILEDLFCGETREPS)
+
+        replicas = list(replicas)
+        logger.debug("replicas received from Rucio: %s" % replicas)
+
+        files_lfn = dict(((e.scope, e.lfn), e) for e in xfiles)
+        logger.debug("files_lfn=%s" % files_lfn)
+
+        for r in replicas:
+            k = r['scope'], r['name']
+            fdat = files_lfn.get(k)
+            if not fdat:  # not requested replica returned?
                 continue
 
-            output = self._try_copytool_for_transfer(copytool, files)
+            fdat.replicas = []  # reset replicas list
 
-        if output is None:
-            raise PilotException('transfer failed')
-        return output
+            def get_preferred_replica(replicas, allowed_schemas):
+                for schema in allowed_schemas:
+                    for replica in replicas:
+                        if replica and replica.startswith('%s://' % schema):
+                            return replica
+                return None
+
+            has_direct_remoteinput_replicas = False
+
+            # local replicas
+            for ddm in fdat.inputddms:  ## iterate over local ddms and check if replica is exist here
+
+                if ddm not in r['rses']:  # no replica found for given local ddm
+                    continue
+
+                fdat.replicas.append((ddm, r['rses'][ddm]))
+
+                if not has_direct_remoteinput_replicas:
+                    has_direct_remoteinput_replicas = bool(get_preferred_replica(r['rses'][ddm], self.direct_remoteinput_allowed_schemas))
+
+            if (not fdat.replicas or (fdat.accessmode == 'direct' and not has_direct_remoteinput_replicas)) and fdat.allowRemoteInputs:
+                if fdat.accessmode == 'direct':
+                    allowed_schemas = self.direct_remoteinput_allowed_schemas
+                else:
+                    allowed_schemas = self.remoteinput_allowed_schemas
+
+                if not fdat.replicas:
+                    logger.info("No local replicas found for lfn=%s but allowRemoteInputs is set => looking for remote inputs" % fdat.lfn)
+                else:
+                    logger.info("Direct access is set but no local direct access files, but allowRemoteInputs is set => looking for remote inputs" % fdat.lfn)
+                logger.info("consider first/closest replica, accessmode=%s, remoteinput_allowed_schemas=%s" % (fdat.accessmode, allowed_schemas))
+                logger.debug('rses=%s' % r['rses'])
+                for ddm, replicas in r['rses'].iteritems():
+                    replica = get_preferred_replica(r['rses'][ddm], self.remoteinput_allowed_schemas)
+                    if not replica:
+                        continue
+
+                    # remoteinput supported replica (root) replica has been found
+                    fdat.replicas.append((ddm, r['rses'][ddm]))
+                    # break # ignore other remote replicas/sites
+
+            # verify filesize and checksum values
+            if fdat.filesize != r['bytes']:
+                logger.warning("Filesize of input file=%s mismatched with value from Rucio replica: filesize=%s, replica.filesize=%s, fdat=%s"
+                               % (fdat.lfn, fdat.filesize, r['bytes'], fdat))
+            if not fdat.filesize:
+                fdat.filesize = r['bytes']
+                logger.warning("Filesize value of input file=%s is not defined, assigning info got from Rucio replica: filesize=" % (fdat.lfn, r['bytes']))
+
+            for ctype in ['adler32', 'md5']:
+                if fdat.checksum.get(ctype) != r[ctype] and r[ctype]:
+                    logger.warning("Checksum value of input file=%s mismatched with info got from Rucio replica: checksum=%s, replica.checksum=%s, fdat=%s"
+                                   % (fdat.lfn, fdat.checksum, r[ctype], fdat))
+                if not fdat.checksum.get(ctype) and r[ctype]:
+                    fdat.checksum[ctype] = r[ctype]
+
+        logger.info('Number of resolved replicas:\n' +
+                    '\n'.join(["lfn=%s: replicas=%s, allowRemoteInputs=%s, is_directaccess=%s"
+                               % (f.lfn, len(f.replicas), f.allowRemoteInputs, f.is_directaccess(ensure_replica=False)) for f in files]))
+
+        return files
+
+    @classmethod
+    def detect_client_location(self, site):  ## TO BE DEPRECATED ONCE RUCIO BUG IS FIXED
+        """
+        Open a UDP socket to a machine on the internet, to get the local IP address
+        of the requesting client.
+        Try to determine the sitename automatically from common environment variables,
+        in this order: SITE_NAME, ATLAS_SITE_NAME, OSG_SITE_NAME. If none of these exist
+        use the fixed string 'ROAMING'.
+        Note: this is a modified Rucio function.  ## TO BE DEPRECATED ONCE RUCIO BUG IS FIXED
+
+        :return: expected location dict for Rucio functions: dict(ip, fqdn, site)
+        """
+
+        ret = {}
+        try:
+            import socket
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.connect(("8.8.8.8", 80))
+            ip = s.getsockname()[0]
+            ret = {'ip': ip, 'fqdn': socket.getfqdn(), 'site': site}
+        except Exception, e:
+            #self.log('socket() failed to lookup local IP')
+            print 'socket() failed to lookup local IP: %s' % e
+
+        return ret
+
+    def transfer_files(self, copytool, files):
+        """
+            Apply transfer of given `files` using passed `copytool` module
+            Should be implemented by custom Staging Client
+            :param files: list of `FileSpec` objects
+            :param copytool: copytool module
+            :raise: PilotException in case of controlled error
+        """
+
+        raise NotImplementedError
+
+    def transfer(self, files, activity='default'):
+        """
+            Automatically stage passed files using copy tools related to given `activity`
+            :param files: list of `FileSpec` objects
+            :raise: PilotException in case of controlled error
+            :return: output of copytool trasfers (to be clarified)
+        """
+
+        copytools = self.acopytools.get(activity) or self.acopytools.get('default')
+
+        if not copytools:
+            raise PilotException('Failed to resolve copytool by activity=%s, acopytools=%s' % (activity, self.acopytools))
+
+        result, errors = None, []
+
+        for name in copytools:
+
+            try:
+                if name not in self.copytool_modules:
+                    raise PilotException('passed unknow copytool with name=%s .. skipped' % name)
+                module = self.copytool_modules[name]['module_name']
+                self.logger.info('Trying to use copytool=%s for activity=%s' % (name, activity))
+                copytool = __import__('pilot.copytool.%s' % module, globals(), locals(), [module], -1)
+            except PilotException, e:
+                errors.append(e)
+                continue
+            except Exception, e:
+                self.logger.warning('Failed to import copytool module=%s, error=%s' % (module, e))
+                self.logger.debug('Error: %s' % e)
+                continue
+            try:
+                result = self.transfer_files(copytool, files)
+            except PilotException, e:
+                errors.append(e)
+            except Exception, e:
+                self.logger.warning('Failed to transfer files using copytool=%s .. skipped; error=%s' % (copytool, e))
+
+            if result:
+                break
+
+        if not result:
+            raise PilotException('Failed to transfer files using copytools=%s, erros=%s' % (copytools, errors))
+
+        return result
 
 
 class StageInClient(StagingClient):
-    def __init__(self, site=None, ddmendpoint=None, copytool_names=None, fallback_copytool='rucio', infosys_instance=None, logger=None):
-        """
-        StageInClient constructor needs either copytool_names or ddmendpoint specified
 
-        :param site: vo site
-        :param ddmendpoint: ddmendpoint where the copytool settings are stored
-        :param copytool_names: name of copytool or list of copytools to use (if this is, given ddmendpoint will be ignored)
-        :param fallback_copytool: name or list of copytools to use if storage settings cannot be retrieved
-        :param logger: logging.Logger object to use for loggin (None means no logging)
-        :return:
+    def transfer_files(self, copytool, files):
         """
-        super(StageInClient, self).__init__(site, ddmendpoint, copytool_names, fallback_copytool, infosys_instance, logger)
+            Automatically stage in files using the selected copy tool module.
 
-    def _try_copytool_for_transfer(self, copytool, files):
+            :param copytool: copytool module
+            :param files: list of `FileSpec` objects
+
+            :return: the output of the copytool transfer operation
+            :raise: PilotException in case of controlled error
         """
-        Automatically stage in files using the selected copy tool.
 
-        :param copytool: copytool to try
-        :param files: List of dictionaries containing the file information
+        if not copytool.is_valid_for_copy_in(files):
+            self.logger.warning('Input is not valid for transfers using copytool=%s' % copytool)
+            self.logger.debug('Input: %s' % files)
+            raise PilotException('Invalid input for transfer operation')
 
-        :return: the output of the copytool or None on error
-        """
-        logger = self.logger
-        try:
-            if not copytool.is_valid_for_copy_in(files):
-                logger.warning('Input is not valid for this copytool')
-                logger.debug('Input: %s' % files)
-                return None
-            return copytool.copy_in(files)
-        except Exception as error:
-            logger.warning('Failed transferring files with this copytool')
-            logger.debug('Error: %s' % error)
-        return None
+        return copytool.copy_in(files)
 
 
 class StageOutClient(StagingClient):
-    def __init__(self, site=None, ddmendpoint=None, copytool_names=None, fallback_copytool='rucio', infosys_instance=None, logger=None):
+
+    def transfer_files(self, copytool, files):
         """
-        StageOutClient constructor needs either copytool_names or ddmendpoint specified
+            Automatically stage out files using the selected copy tool module.
 
-        :param site: vo site
-        :param ddmendpoint: ddmendpoint where the copytool settings are stored
-        :param copytool_names: name of copytool or list of copytools to use (if this is, given ddmendpoint will be ignored)
-        :param fallback_copytool: name or list of copytools to use if storage settings cannot be retrieved
-        :param logger: logging.Logger object to use for loggin (None means no logging)
+            :param copytool: copytool module
+            :param files: list of `FileSpec` objects
+
+            :return: the output of the copytool transfer operation
+            :raise: PilotException in case of controlled error
         """
-        super(StageOutClient, self).__init__(site, ddmendpoint, copytool_names, fallback_copytool, infosys_instance, logger)
 
-    def _try_copytool_for_transfer(self, copytool, files):
-        """
-        Automatically stage out files using rucio.
+        if not copytool.is_valid_for_copy_out(files):
+            self.logger.warning('Input is not valid for transfers using copytool=%s' % copytool)
+            self.logger.debug('Input: %s' % files)
+            raise PilotException('Invalid input for transfer operation')
 
-        :param copytool: copytool to try for the transfer
-        :param files: List of dictionaries containing the target scope, the path to the file, and destination RSE
+        return copytool.copy_out(files)
 
-        :return: the output of the copytool or None on error
-        """
-        logger = self.logger
-        try:
-            if not copytool.is_valid_for_copy_out(files):
-                logger.warning('Input is not valid for this copytool')
-                logger.debug('Input: %s' % files)
-                return None
-            return copytool.copy_out(files)
-        except Exception as error:
-            logger.warning('Failed transferring files with this copytool')
-            logger.debug('Error: %s' % error)
-        return None
-
-
-class StageInClientAsync(object):
-    def __init__(self, site):
-        raise NotImplementedError
-
-    def queue(self, files):
-        raise NotImplementedError
-
-    def is_transferring(self):
-        raise NotImplementedError
-
-    def start(self):
-        raise NotImplementedError
-
-    def finish(self):
-        raise NotImplementedError
-
-    def status(self):
-        raise NotImplementedError
-
-
-class StageOutClientAsync(object):
-    def __init__(self, site):
-        raise NotImplementedError
-
-    def queue(self, files):
-        raise NotImplementedError
-
-    def is_transferring(self):
-        raise NotImplementedError
-
-    def start(self):
-        raise NotImplementedError
-
-    def finish(self):
-        raise NotImplementedError
-
-    def status(self):
-        raise NotImplementedError
+#class StageInClientAsync(object):
+#
+#    def __init__(self, site):
+#        raise NotImplementedError
+#
+#    def queue(self, files):
+#        raise NotImplementedError
+#
+#    def is_transferring(self):
+#        raise NotImplementedError
+#
+#    def start(self):
+#        raise NotImplementedError
+#
+#    def finish(self):
+#        raise NotImplementedError
+#
+#    def status(self):
+#        raise NotImplementedError
+#
+#
+#class StageOutClientAsync(object):
+#
+#    def __init__(self, site):
+#        raise NotImplementedError
+#
+#    def queue(self, files):
+#        raise NotImplementedError
+#
+#    def is_transferring(self):
+#        raise NotImplementedError
+#
+#    def start(self):
+#        raise NotImplementedError
+#
+#    def finish(self):
+#        raise NotImplementedError
+#
+#    def status(self):
+#        raise NotImplementedError

--- a/pilot/common/errorcodes.py
+++ b/pilot/common/errorcodes.py
@@ -23,13 +23,18 @@ class ErrorCodes:
     GENERALERROR = 1008
     NOLOCALSPACE = 1098
     STAGEINFAILED = 1099
+    REPLICANOTFOUND = 1100
     NOSUCHFILE = 1103
     SETUPFAILURE = 1110
     MKDIR = 1134
     STAGEOUTFAILED = 1137
+    PUTMD5MISMATCH = 1141
+    GETMD5MISMATCH = 1145
     STAGEINTIMEOUT = 1151  # called GETTIMEOUT in Pilot 1
     STAGEOUTTIMEOUT = 1152  # called PUTTIMEOUT in Pilot 1
     NOPROXY = 1163
+    GETADMISMATCH = 1171
+    PUTADMISMATCH = 1172
     NOVOMSPROXY = 1177
 
     # Error code constants (new since Pilot 2)
@@ -49,10 +54,15 @@ class ErrorCodes:
         GENERALERROR: "General pilot error, consult batch log",
         NOLOCALSPACE: "Not enough local space",
         STAGEINFAILED: "Failed to stage-in file",
+        REPLICANOTFOUND: "Replica not found",
         NOSUCHFILE: "No such file or directory",
         SETUPFAILURE: "Failed during payload setup",
         MKDIR: "Failed to create local directory",
         STAGEOUTFAILED: "Failed to stage-out file",
+        PUTMD5MISMATCH: "md5sum mismatch on output file",
+        GETMD5MISMATCH: "md5sum mismatch on input file",
+        GETADMISMATCH: "adler32 mismatch on input file",
+        PUTADMISMATCH: "adler32 mismatch on output file",
         STAGEINTIMEOUT: "File transfer timed out during stage-in",
         STAGEOUTTIMEOUT: "File transfer timed out during stage-out",
         NOPROXY: "Grid proxy not valid",

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -487,8 +487,9 @@ def _stage_out_all(job, args):
     else:
         log.info('will stage-out all output files and log file')
         if job.metadata:
+            scopes = dict([e.lfn, e.scope] for e in job.outdata)  # quick hack: to be properly implemented later
             for f in job.metadata['files']['output']:
-                outputs[f['subFiles'][0]['name']] = {'scope': job.scopeout,
+                outputs[f['subFiles'][0]['name']] = {'scope': scopes.get(f['subFiles'][0]['name'], job.scopeout.split(',')[0]),
                                                      'name': f['subFiles'][0]['name'],
                                                      'guid': f['subFiles'][0]['file_guid'],
                                                      'bytes': f['subFiles'][0]['file_size']}

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -18,6 +18,7 @@ import subprocess
 import tarfile
 import time
 
+from pilot.api.data import StageInClient
 from pilot.control.job import send_state
 from pilot.common.errorcodes import ErrorCodes
 from pilot.common.exception import ExcThread
@@ -139,26 +140,29 @@ def _call(args, executable, job, cwd=os.getcwd(), logger=logger):
 
 
 def _stage_in(args, job):
+    """
+        :return: True in case of success
+    """
+
     log = logger.getChild(job.jobid)
 
-    os.environ['RUCIO_LOGGING_FORMAT'] = '{0}%(asctime)s %(levelname)s [%(message)s]'
+    try:
+        client = StageInClient(job.infosys, logger=log)
+        kwargs = dict(workdir=job.workdir, cwd=job.workdir, usecontainer=False, job=job)
+        client.transfer(job.indata, activity='pr', **kwargs)
+    except Exception, error:
+        log.error('Failed to stage-in: error=%s' % error)
+        #return False
 
-    for fspec in job.indata:
+    log.info('Summary of transferred files:')
+    for e in job.indata:
+        log.info(" -- lfn=%s, status_code=%s, status=%s" % (e.lfn, e.status_code, e.status))
 
-        executable = ['/usr/bin/env',
-                      'rucio', '-v', 'download',
-                      '--no-subdir',
-                      '--rse', fspec.ddmendpoint,
-                      '%s:%s' % (fspec.scope, fspec.lfn)]
+    log.info("stagein finished")
 
-        if not _call(args,
-                     executable,
-                     job,
-                     cwd=job.workdir,
-                     logger=log):
-            return False
+    remain_files = [e for e in job.indata if e.status not in ['remote_io', 'transferred', 'no_transfer']]
 
-    return True
+    return not remain_files
 
 
 def stage_in_auto(site, files):
@@ -314,6 +318,7 @@ def copytool_in(queues, traces, args):
             send_state(job, args, 'running')
 
             logger.info('Test job.infosys: queuedata.copytools=%s' % job.infosys.queuedata.copytools)
+            logger.info('Test job.infosys: queuedata.acopytools=%s' % job.infosys.queuedata.acopytools)
 
             if _stage_in(args, job):
                 queues.finished_data_in.put(job)

--- a/pilot/copytool/gfal.py
+++ b/pilot/copytool/gfal.py
@@ -59,9 +59,9 @@ def copy_in(files, **kwargs):
     if not check_for_gfal():
         raise StageInFailure("No GFAL2 tools found")
 
-    dst = kwargs.get('workdir') or '.'
-
     for fspec in files:
+
+        dst = fspec.workdir or kwargs.get('workdir') or '.'
 
         timeout = get_timeout(fspec.filesize)
         source = fspec.turl

--- a/pilot/copytool/gfal.py
+++ b/pilot/copytool/gfal.py
@@ -67,7 +67,7 @@ def copy_in(files, **kwargs):
         source = fspec.turl
         destination = "file://%s" % os.path.abspath(os.path.join(dst, fspec.lfn))
 
-        cmd = ['gfal-copy --verbose -f', ' -t', timeout]
+        cmd = ['gfal-copy --verbose -f', ' -t %s' % timeout]
 
         if fspec.checksum:
             cmd += ['-K', '%s:%s' % fspec.checksum.items()[0]]

--- a/pilot/copytool/rucio.py
+++ b/pilot/copytool/rucio.py
@@ -10,8 +10,7 @@
 import os
 import re
 
-from pilot.common.errorcodes import ErrorCodes
-from pilot.common.exception import PilotException
+from pilot.common.exception import PilotException, ErrorCodes
 
 from pilot.util.container import execute
 

--- a/pilot/copytool/rucio.py
+++ b/pilot/copytool/rucio.py
@@ -45,9 +45,8 @@ def copy_in(files, **kwargs):
     # don't spoil the output, we depend on stderr parsing
     os.environ['RUCIO_LOGGING_FORMAT'] = '%(asctime)s %(levelname)s [%(message)s]'
 
-    dst = kwargs.get('workdir') or '.'
-
     for fspec in files:
+        dst = fspec.workdir or kwargs.get('workdir') or '.'
         cmd = ['/usr/bin/env', 'rucio', '-v', 'download', '--no-subdir', '--dir', dst]
         if require_replicas:
             cmd += ['--rse', fspec.replicas[0][0]]

--- a/pilot/info/configinfo.py
+++ b/pilot/info/configinfo.py
@@ -59,8 +59,10 @@ class PilotConfigProvider(object):
                 #'container_options': '-B /cvmfs,/scratch,/etc/grid-security --contain',  ## for testing
                 #'catchall': "singularity_options='-B /cvmfs000' catchx=1",  ## for testing
                 'es_stageout_gap': 601,  # in seconds, for testing: FIXME LATER,
-                'acopytools': ast.literal_eval(self.config.Information.acopytools),
                 }
+
+        if hasattr(self.config.Information, 'acopytools'):  ## FIX ME LATER: Config API should reimplemented/fixed later
+            data['acopytools'] = ast.literal_eval(self.config.Information.acopytools)
 
         logger.info('queuedata: following keys will be overwritten by config values: %s' % data)
 

--- a/pilot/info/configinfo.py
+++ b/pilot/info/configinfo.py
@@ -52,12 +52,14 @@ class PilotConfigProvider(object):
             :return: dict of settings for given PandaQueue as a key
         """
 
+        import ast
         data = {'maxwdir': 10555,  # in MB
                 'maxwdir_broken': self.config.Pilot.maximum_input_file_sizes,  # ## Config API is broken -- FIXME LATER
                 #'container_type': 'singularity:pilot;docker:wrapper',  # ## for testing
                 #'container_options': '-B /cvmfs,/scratch,/etc/grid-security --contain',  ## for testing
                 #'catchall': "singularity_options='-B /cvmfs000' catchx=1",  ## for testing
                 'es_stageout_gap': 601,  # in seconds, for testing: FIXME LATER,
+                'acopytools': ast.literal_eval(self.config.Information.acopytools),
                 }
 
         logger.info('queuedata: following keys will be overwritten by config values: %s' % data)

--- a/pilot/info/filespec.py
+++ b/pilot/info/filespec.py
@@ -57,12 +57,13 @@ class FileSpec(BaseData):
     mtime = 0         # file modification time
     status = None     # file transfer status value
     status_code = 0   # file transfer status code
+    inputddms = []    # list of DDMEndpoint names which will be considered by default (if set) as allowed storage for input replicas
 
     # specify the type of attributes for proper data validation and casting
     _keys = {int: ['filesize', 'mtime', 'status_code'],
              str: ['lfn', 'guid', 'checksum', 'scope', 'dataset', 'ddmendpoint',
                    'type', 'surl', 'turl', 'status'],
-             list: ['replicas'],
+             list: ['replicas', 'inputddms'],
              bool: []
              }
 

--- a/pilot/info/filespec.py
+++ b/pilot/info/filespec.py
@@ -58,7 +58,7 @@ class FileSpec(BaseData):
     status = None     # file transfer status value
     status_code = 0   # file transfer status code
     inputddms = []    # list of DDMEndpoint names which will be considered by default (if set) as allowed storage for input replicas
-    workdir = None    # used to declare file-specific work dir (location on give file while it's used for transfer by copytool)
+    workdir = None    # used to declare file-specific work dir (location of given local file when it's used for transfer by copytool)
 
     # specify the type of attributes for proper data validation and casting
     _keys = {int: ['filesize', 'mtime', 'status_code'],

--- a/pilot/info/filespec.py
+++ b/pilot/info/filespec.py
@@ -58,11 +58,12 @@ class FileSpec(BaseData):
     status = None     # file transfer status value
     status_code = 0   # file transfer status code
     inputddms = []    # list of DDMEndpoint names which will be considered by default (if set) as allowed storage for input replicas
+    workdir = None    # used to declare file-specific work dir (location on give file while it's used for transfer by copytool)
 
     # specify the type of attributes for proper data validation and casting
     _keys = {int: ['filesize', 'mtime', 'status_code'],
              str: ['lfn', 'guid', 'checksum', 'scope', 'dataset', 'ddmendpoint',
-                   'type', 'surl', 'turl', 'status'],
+                   'type', 'surl', 'turl', 'status', 'workdir'],
              list: ['replicas', 'inputddms'],
              bool: []
              }

--- a/pilot/info/filespec.py
+++ b/pilot/info/filespec.py
@@ -51,12 +51,12 @@ class FileSpec(BaseData):
 
     ## local keys
     type = ''         # type of File: input, output of log
-    replicas = []     # list of resolved input replicas
+    replicas = None   # list of resolved input replicas
     surl = ''         # source url
     turl = ''         # transfer url
     mtime = 0         # file modification time
     status = None     # file transfer status value
-    status_code = 0   # file trsansfer status code
+    status_code = 0   # file transfer status code
 
     # specify the type of attributes for proper data validation and casting
     _keys = {int: ['filesize', 'mtime', 'status_code'],

--- a/pilot/info/infoservice.py
+++ b/pilot/info/infoservice.py
@@ -62,6 +62,10 @@ class InfoService(object):
         self.storages_info = {}   ## cache of QueueData objects for DDMEndpoint settings
         #self.sites_info = {}     ## cache for Site settings
 
+        self.confinfo = None   ## by default (when non initalized) ignore overwrites/settings from Config
+        self.jobinfo = None    ## by default (when non initalized) ignore overwrites/settings from Job
+        self.extinfo = ExtInfoProvider(cache_time=self.cache_time)
+
     def init(self, pandaqueue, confinfo=None, extinfo=None, jobinfo=None):
 
         self.confinfo = confinfo or PilotConfigProvider()
@@ -72,6 +76,10 @@ class InfoService(object):
 
         if not self.pandaqueue:
             raise PilotException('Failed to initialize InfoService: panda queue name is not set')
+
+        self.queues_info = {}     ##  reset cache data
+        self.storages_info = {}   ##  reset cache data
+        #self.sites_info = {}     ##  reset cache data
 
         self.queuedata = self.resolve_queuedata(self.pandaqueue)
 
@@ -141,7 +149,7 @@ class InfoService(object):
 
         return cache.get(pandaqueue)
 
-    @require_init
+    #@require_init
     def resolve_storage_data(self, ddmendpoints=[]):  ## high level API
         """
             :return: dict of DDMEndpoint settings by DDMEndpoint name as a key

--- a/pilot/info/jobdata.py
+++ b/pilot/info/jobdata.py
@@ -375,8 +375,11 @@ class JobData(BaseData):
             Extract from jobparams non related to Job options
         """
 
+        ## clean job params from Pilot1 old-formatted options
+        ret = re.sub(r"--overwriteQueuedata={.*?}", "", value)
+
         ## extract overwrite options
-        options, ret = self.parse_args(value, {'--overwriteQueueData': lambda x: ast.literal_eval(x) if x else {}}, remove=True)
+        options, ret = self.parse_args(ret, {'--overwriteQueueData': lambda x: ast.literal_eval(x) if x else {}}, remove=True)
         self.overwrite_queuedata = options.get('--overwriteQueueData', {})
 
         # extract zip map  ## TO BE FIXED? better to pass it via dedicated sub-option in jobParams from PanDA side: e.g. using --zipmap "content"

--- a/pilot/test/test_harvester.py
+++ b/pilot/test/test_harvester.py
@@ -218,12 +218,11 @@ class TestHarvesterStageOut(unittest.TestCase):
 
     def setUp(self):
         # skip tests if running through Travis -- github does not have working rucio
-        self.travis = False
-        if os.environ.get('TRAVIS') == 'true':
-            self.travis = True
+
+        self.travis = os.environ.get('TRAVIS') == 'true'
 
         # setup pilot data client
-        self.data_client = data.StageOutClient(site='CERN-PROD', copytool_names=['rucio'])
+        self.data_client = data.StageOutClient(acopytools=['rucio'])
 
     def test_stageout_fail_notfound(self):
         '''

--- a/pilot/test/test_harvester.py
+++ b/pilot/test/test_harvester.py
@@ -46,12 +46,19 @@ class TestHarvesterStageIn(unittest.TestCase):
 
     def setUp(self):
         # skip tests if running through Travis -- github does not have working rucio
-        self.travis = False
-        if os.environ.get('TRAVIS') == 'true':
-            self.travis = True
+        self.travis = os.environ.get('TRAVIS') == 'true'
 
         # setup pilot data client
-        self.data_client = data.StageInClient(site='CERN-PROD', copytool_names=['rucio'])
+
+        # 1st example: using StageIn client with infosys
+        # initialize StageInClient using infosys component to resolve allowed input sources
+        #from pilot.info import infosys
+        #infosys.init('ANALY_CERN')
+        #self.data_client = data.StageInClient(infosys)
+
+        # 2nd example: avoid using infosys instance but it requires to pass explicitly copytools and allowed input Strorages in order to resolve replicas
+        #self.data_client = data.StageInClient(acopytools={'pr':'rucio'})
+        self.data_client = data.StageInClient(acopytools='rucio')  ## use rucio everywhere
 
     def test_stagein_sync_fail_nodirectory(self):
         '''
@@ -102,6 +109,8 @@ class TestHarvesterStageIn(unittest.TestCase):
         if self.travis:
             return True
 
+        ## if infosys was not passed to StageInClient in constructor
+        ## then it's mandatory to specify allowed `inputddms` that can be used as source for replica lookup
         tmp_dir1, tmp_dir2 = tempfile.mkdtemp(), tempfile.mkdtemp()
         result = self.data_client.transfer(files=[{'scope': 'no_scope1',
                                                    'name': 'no_name1',

--- a/pilot/util/default.cfg
+++ b/pilot/util/default.cfg
@@ -82,6 +82,8 @@ schedconfig: http://pandaserver.cern.ch:25085/cache/schedconfig
 # File name for the queuedata json
 queuedata: queuedata.json
 
+# overwrite acopytools for queuedata
+#acopytools: {'pr':['rucio']}
 
 ################################
 # Payload parameters
@@ -122,6 +124,3 @@ job_request_file: worker_requestjob.json
 # Name of the kill worker file. The pilot places this file in the pilot launch directory when it has finished all jobs
 # and wants Harvester to kill the worker (virtual machine)
 kill_worker_file: kill_worker
-
-
-

--- a/pilot/util/default.cfg
+++ b/pilot/util/default.cfg
@@ -84,6 +84,7 @@ queuedata: queuedata.json
 
 # overwrite acopytools for queuedata
 #acopytools: {'pr':['rucio']}
+#acopytools: {'pr':['gfalcopy']}
 
 ################################
 # Payload parameters


### PR DESCRIPTION
re-factoring of Data API (`pilot.api.data`):
  - simplified and fixed workflow for Stage clients
  - implemented `resolve_replicas()` which fetches replica details from Rucio and populates FileSpec objects
  - pilot.api.data updates (invoke resolve_replicas if need -- `require_replicas` )
  - implemented (default) resolve_replica function (a copytool can overwrite it and customize allowed schemas)
 - allow to run transfers without `infosys` initialization (but requires to explicitly set `inputddms` data for files in order to resolve allowed source for replica lookup)

`pilot.control.data` updates:
 - use data API for stage in
 - `rucio` mover upgrade (use filespec as input for stage-in)
 - `gfal` copytool: reimplemented stage-in operation using FileSpecs as input
 - fix stage-out logic (bug fix)

`pilot.info`
- allow to overwrite acopytools data by values from Config file 
- ignore Pilot1 bad formatted `--overwriteQueuedata option`
- make resolve_storage_data() less strict and allow to use it without `infosys` initialization (which considers only data from ext source provider)
 - various fixes and updates

An example how to explicitly use given copytool(s) (for tests): -- `default.cfg` config file

```
# overwrite acopytools for queuedata
#acopytools: {'pr':['rucio']}
acopytools: {'pr':['gfalcopy']}
```
