### PR TITLE
data API updates (StageOutClient); xrdcp, gfal copytools upgrade

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -484,6 +484,29 @@ class StageOutClient(StagingClient):
 
         return {'surl': surl}
 
+    @classmethod
+    def calc_adler32_checksum(self, filename):
+        """
+            calculate the adler32 checksum for a file
+            raise an exception if input filename is not exist/readable
+        """
+
+        from zlib import adler32
+
+        asum = 1  # default adler32 starting value
+        blocksize = 64 * 1024 * 1024  # read buffer size, 64 Mb
+
+        with open(filename, 'rb') as f:
+            while True:
+                data = f.read(blocksize)
+                if not data:
+                    break
+                asum = adler32(data, asum)
+                if asum < 0:
+                    asum += 2**32
+
+        return "%08x" % asum  # convert to hex
+
     def transfer_files(self, copytool, files, activity, **kwargs):
         """
             Automatically stage out files using the selected copy tool module.

--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -306,7 +306,7 @@ class StagingClient(object):
                 self.logger.error(traceback.format_exc())
                 errors.append(e)
 
-            if errors and isinstance(errors[-1], PilotException) and errors[-1].code == ErrorCodes.MISSINGOUTPUTFILE:
+            if errors and isinstance(errors[-1], PilotException) and errors[-1].get_error_code() == ErrorCodes.MISSINGOUTPUTFILE:
                 raise errors[-1]
             if result:
                 break

--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -307,6 +307,8 @@ class StagingClient(object):
                 self.logger.error(traceback.format_exc())
                 errors.append(e)
 
+            if errors and isinstance(errors[-1], PilotException) and errors[-1].code == ErrorCodes.MISSINGOUTPUTFILE:
+                raise errors[-1]
             if result:
                 break
 
@@ -363,7 +365,7 @@ class StageInClient(StagingClient):
             :return: the output of the copytool transfer operation
             :raise: PilotException in case of controlled error
         """
-
+        return True
         if getattr(copytool, 'require_replicas', False) and files and files[0].replicas is None:
             files = self.resolve_replicas(files)
             allowed_schemas = getattr(copytool, 'allowed_schemas', None)

--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -279,7 +279,6 @@ class StagingClient(object):
 
         result, errors = None, []
 
-        self.logger.info('files=%s' % files)
         for name in copytools:
 
             try:
@@ -365,7 +364,7 @@ class StageInClient(StagingClient):
             :return: the output of the copytool transfer operation
             :raise: PilotException in case of controlled error
         """
-        return True
+
         if getattr(copytool, 'require_replicas', False) and files and files[0].replicas is None:
             files = self.resolve_replicas(files)
             allowed_schemas = getattr(copytool, 'allowed_schemas', None)
@@ -390,6 +389,8 @@ class StageInClient(StagingClient):
 
         if self.infosys:
             kwargs['copytools'] = self.infosys.queuedata.copytools
+
+        self.logger.info('Ready to transfer (stage-in) files: %s' % files)
 
         return copytool.copy_in(files, **kwargs)
 
@@ -571,6 +572,8 @@ class StageOutClient(StagingClient):
             self.logger.warning('Input is not valid for transfers using copytool=%s' % copytool)
             self.logger.debug('Input: %s' % files)
             raise PilotException('Invalid input for transfer operation')
+
+        self.logger.info('Ready to transfer (stage-out) files: %s' % files)
 
         if self.infosys:
             kwargs['copytools'] = self.infosys.queuedata.copytools

--- a/pilot/common/errorcodes.py
+++ b/pilot/common/errorcodes.py
@@ -42,6 +42,7 @@ class ErrorCodes:
     GETADMISMATCH = 1171
     PUTADMISMATCH = 1172
     NOVOMSPROXY = 1177
+    CHKSUMNOTSUP = 1242
 
     # Error code constants (new since Pilot 2)
     NOTIMPLEMENTED = 1300
@@ -90,7 +91,9 @@ class ErrorCodes:
         SINGULARITYBINDPOINTFAILURE: "Singularity: Not mounting requested bind point",
         SINGULARITYIMAGEMOUNTFAILURE: "Singularity: Failed to mount image",
         PAYLOADEXECUTIONEXCEPTION: "Exception caught during payload execution",
-        NOSTORAGEPROTOCOL: "No protocol defined for storage endpoint"
+        NOSTORAGEPROTOCOL: "No protocol defined for storage endpoint",
+        CHKSUMNOTSUP: "Mover error: query checksum is not supported",
+
     }
 
     def get_error_message(self, errorcode):

--- a/pilot/common/errorcodes.py
+++ b/pilot/common/errorcodes.py
@@ -37,6 +37,8 @@ class ErrorCodes:
     STAGEINTIMEOUT = 1151  # called GETTIMEOUT in Pilot 1
     STAGEOUTTIMEOUT = 1152  # called PUTTIMEOUT in Pilot 1
     NOPROXY = 1163
+    MISSINGOUTPUTFILE = 1165
+
     GETADMISMATCH = 1171
     PUTADMISMATCH = 1172
     NOVOMSPROXY = 1177
@@ -53,6 +55,7 @@ class ErrorCodes:
     SINGULARITYBINDPOINTFAILURE = 1308
     SINGULARITYIMAGEMOUNTFAILURE = 1309
     PAYLOADEXECUTIONEXCEPTION = 1310
+    NOSTORAGEPROTOCOL = 1311
 
     _error_messages = {
         GENERALERROR: "General pilot error, consult batch log",
@@ -67,6 +70,7 @@ class ErrorCodes:
         STAGEOUTFAILED: "Failed to stage-out file",
         PUTMD5MISMATCH: "md5sum mismatch on output file",
         GETMD5MISMATCH: "md5sum mismatch on input file",
+        MISSINGOUTPUTFILE: "Local output file is missing",
         TRFDOWNLOADFAILURE: "Transform could not be downloaded",
         LOOPINGJOB: "Looping job killed by pilot",
         STAGEINTIMEOUT: "File transfer timed out during stage-in",
@@ -85,7 +89,8 @@ class ErrorCodes:
         SINGULARITYNOLOOPDEVICES: "Singularity: No more available loop devices",
         SINGULARITYBINDPOINTFAILURE: "Singularity: Not mounting requested bind point",
         SINGULARITYIMAGEMOUNTFAILURE: "Singularity: Failed to mount image",
-        PAYLOADEXECUTIONEXCEPTION: "Exception caught during payload execution"
+        PAYLOADEXECUTIONEXCEPTION: "Exception caught during payload execution",
+        NOSTORAGEPROTOCOL: "No protocol defined for storage endpoint"
     }
 
     def get_error_message(self, errorcode):

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -555,8 +555,7 @@ def _stage_out_new(job, args):
         # prepare log file
         # consider only 1st available log file
         logfile = job.logdata[0]
-        r = prepare_log(job, logfile, 'tarball_PandaJob_%s_%s' % (job.jobid, job.infosys.pandaqueue))
-        logfile.filesize = r['bytes']  ## FIX ME LATER: do simplify prepare_log function
+        prepare_log(job, logfile, 'tarball_PandaJob_%s_%s' % (job.jobid, job.infosys.pandaqueue))
 
         if not _do_stageout(job, [logfile], ['pl', 'pw', 'w'], 'log'):
             is_success = False

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -512,7 +512,7 @@ def _do_stageout(job, xdata, activity, title):
 
     try:
         # check if file exists before actual processing
-        # populate filesize if need
+        # populate filesize if need, calc checksum
         for fspec in xdata:
             pfn = getattr(fspec, 'pfn', None) or os.path.join(job.workdir, fspec.lfn)
             if not os.path.isfile(pfn) or not os.access(pfn, os.R_OK):
@@ -523,6 +523,8 @@ def _do_stageout(job, xdata, activity, title):
                 fspec.filesize = os.path.getsize(pfn)
             fspec.surl = pfn
             fspec.activity = activity
+            if not fspec.checksum.get('adler32'):
+                fspec.checksum['adler32'] = client.calc_adler32_checksum(pfn)
 
         client.transfer(xdata, activity, **kwargs)
 

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -101,7 +101,7 @@ def use_container(cmd):
     return usecontainer
 
 
-def _call(args, executable, job, cwd=os.getcwd(), logger=logger):
+def _call(args, executable, job, cwd=os.getcwd(), logger=logger):  ### TO BE DEPRECATED
     try:
         # for containers, we can not use a list
         usecontainer = use_container(executable[1])
@@ -593,6 +593,7 @@ def _stage_out_new(job, args):
                                'surl': e.turl}
 
     job.fileinfo = fileinfo
+    log.info('prepared job.fileinfo=%s' % job.fileinfo)
 
     if not is_success:
         # set error code + message (a more precise error code might have been set already)

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -502,32 +502,13 @@ def _do_stageout(job, xdata, activity, title):
     """
 
     log = get_logger(job.jobid)
-
     log.info('prepare to stage-out %s files' % title)
 
     error = None
-
-    client = StageOutClient(job.infosys, logger=log)
-    kwargs = dict(workdir=job.workdir, cwd=job.workdir, usecontainer=False, job=job)
-
     try:
-        # check if file exists before actual processing
-        # populate filesize if need, calc checksum
-        for fspec in xdata:
-            pfn = getattr(fspec, 'pfn', None) or os.path.join(job.workdir, fspec.lfn)
-            if not os.path.isfile(pfn) or not os.access(pfn, os.R_OK):
-                msg = "Error: output pfn file does not exist: %s" % pfn
-                log.error(msg)
-                raise PilotException(msg, code=ErrorCodes.MISSINGOUTPUTFILE, state="FILE_INFO_FAIL")
-            if not fspec.filesize:
-                fspec.filesize = os.path.getsize(pfn)
-            fspec.surl = pfn
-            fspec.activity = activity
-            if not fspec.checksum.get('adler32'):
-                fspec.checksum['adler32'] = client.calc_adler32_checksum(pfn)
-
+        client = StageOutClient(job.infosys, logger=log)
+        kwargs = dict(workdir=job.workdir, cwd=job.workdir, usecontainer=False, job=job)
         client.transfer(xdata, activity, **kwargs)
-
     except PilotException, error:
         import traceback
         log.error(traceback.format_exc())

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -552,8 +552,7 @@ def _stage_out_new(job, args):
             log.warning('transfer of output file(s) failed')
 
     if job.stageout in ['log', 'all'] and job.logdata:  ## do stage-out log files
-        # prepare log file
-        # consider only 1st available log file
+        # prepare log file, consider only 1st available log file
         logfile = job.logdata[0]
         prepare_log(job, logfile, 'tarball_PandaJob_%s_%s' % (job.jobid, job.infosys.pandaqueue))
 

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -9,6 +9,7 @@
 # - Daniel Drizhuk, d.drizhuk@gmail.com, 2017
 # - Paul Nilsson, paul.nilsson@cern.ch, 2017-2018
 # - Wen Guan, wen.guan@cern.ch, 2018
+# - Alexey Anisenkov, anisyonk@cern.ch, 2018
 
 import copy
 import Queue
@@ -20,10 +21,10 @@ import time
 
 from contextlib import closing  # for Python 2.6 compatibility - to fix a problem with tarfile
 
-from pilot.api.data import StageInClient
+from pilot.api.data import StageInClient, StageOutClient
 from pilot.control.job import send_state
 from pilot.common.errorcodes import ErrorCodes
-from pilot.common.exception import ExcThread
+from pilot.common.exception import ExcThread, PilotException
 from pilot.util.auxiliary import get_logger
 from pilot.util.config import config
 from pilot.util.constants import PILOT_PRE_STAGEIN, PILOT_POST_STAGEIN, PILOT_PRE_STAGEOUT, PILOT_POST_STAGEOUT
@@ -367,7 +368,7 @@ def copytool_out(queues, traces, args):
 
             # send_state(job, args, 'running')  # not necessary to send job update at this point?
 
-            if _stage_out_all(job, args):
+            if _stage_out_new(job, args):
                 queues.finished_data_out.put(job)
             else:
                 queues.failed_data_out.put(job)
@@ -402,7 +403,7 @@ def prepare_log(job, logfile, tarball_name):
             'bytes': os.stat(os.path.join(job.workdir, logfile.lfn)).st_size}
 
 
-def _stage_out(args, outfile, job):
+def _stage_out(args, outfile, job):  ### TO BE DEPRECATED
     log = get_logger(job.jobid)
 
     # write time stamps to pilot timing file
@@ -494,13 +495,131 @@ def _stage_out(args, outfile, job):
     return summary
 
 
-def _stage_out_all(job, args):
+def _do_stageout(job, xdata, activity, title):
+    """
+        :return: True in case of success transfers
+        :raise: PilotException in case of controlled error
+    """
+
+    log = get_logger(job.jobid)
+
+    log.info('prepare to stage-out %s files' % title)
+
+    error = None
+
+    client = StageOutClient(job.infosys, logger=log)
+    kwargs = dict(workdir=job.workdir, cwd=job.workdir, usecontainer=False, job=job)
+
+    try:
+        # check if file exists before actual processing
+        # populate filesize if need
+        for fspec in xdata:
+            pfn = getattr(fspec, 'pfn', None) or os.path.join(job.workdir, fspec.lfn)
+            if not os.path.isfile(pfn) or not os.access(pfn, os.R_OK):
+                msg = "Error: output pfn file does not exist: %s" % pfn
+                log.error(msg)
+                raise PilotException(msg, code=ErrorCodes.MISSINGOUTPUTFILE, state="FILE_INFO_FAIL")
+            if not fspec.filesize:
+                fspec.filesize = os.path.getsize(pfn)
+            fspec.surl = pfn
+            fspec.activity = activity
+
+        client.transfer(xdata, activity, **kwargs)
+
+    except PilotException, error:
+        import traceback
+        log.error(traceback.format_exc())
+    except Exception, e:
+        import traceback
+        log.error(traceback.format_exc())
+        error = PilotException("stageOut failed with error=%s" % e, code=ErrorCodes.STAGEOUTFAILED)
+
+    log.info('Summary of transferred files:')
+    for e in xdata:
+        log.info(" -- lfn=%s, status_code=%s, status=%s" % (e.lfn, e.status_code, e.status))
+
+    if error:
+        log.error('Failed to stage-out %s file(s): error=%s' % (error, title))
+        raise error
+
+    remain_files = [e for e in xdata if e.status not in ['transferred']]
+
+    return not remain_files
+
+
+def _stage_out_new(job, args):
+    """
+    Stage-out of all output files.
+    If job.stageout=log then only log files will be transferred.
+
+    :param job: job object
+    :param args:
+    :return: True in case of success
+    """
+
+    log = get_logger(job.jobid)
+
+    # write time stamps to pilot timing file
+    add_to_pilot_timing(job.jobid, PILOT_PRE_STAGEOUT, time.time())
+
+    is_success = True
+    if job.stageout != 'log':  ## do stage-out output files
+        if not _do_stageout(job, job.outdata, ['pw', 'w'], 'output'):
+            is_success = False
+            log.warning('transfer of output file(s) failed')
+
+    if job.stageout in ['log', 'all'] and job.logdata:  ## do stage-out log files
+        # prepare log file
+        # consider only 1st available log file
+        logfile = job.logdata[0]
+        r = prepare_log(job, logfile, 'tarball_PandaJob_%s_%s' % (job.jobid, job.infosys.pandaqueue))
+        logfile.filesize = r['bytes']  ## FIX ME LATER: do simplify prepare_log function
+
+        if not _do_stageout(job, [logfile], ['pl', 'pw', 'w'], 'log'):
+            is_success = False
+            log.warning('log transfer failed')
+
+    # write time stamps to pilot timing file
+    add_to_pilot_timing(job.jobid, PILOT_POST_STAGEOUT, time.time())
+
+    # generate fileinfo details to be send to Panda
+    fileinfo = {}
+    for e in job.outdata + job.logdata:
+        if e.status in ['transferred']:
+            fileinfo[e.lfn] = {'guid': e.guid, 'fsize': e.filesize,
+                               'adler32': e.checksum.get('adler32'),
+                               'surl': e.turl}
+
+    job.fileinfo = fileinfo
+
+    if not is_success:
+        # set error code + message (a more precise error code might have been set already)
+        job.piloterrorcodes, job.piloterrordiags = errors.add_error_code(errors.STAGEOUTFAILED)
+        job.state = "failed"
+        log.warning('stage-out failed')  # with error: %d, %s (setting job state to failed)' %
+        # log.warning('stage-out failed with error: %d, %s (setting job state to failed)' %
+        #  (job['pilotErrorCode'], job['pilotErrorDiag']))
+        # send_state(job, args, 'failed')
+        return False
+
+    log.info('stage-out finished correctly')
+
+    if not job.state:  # is the job state already set? if so, don't change the state
+        job.state = "finished"
+
+    # send final server update since all transfers have finished correctly
+    # send_state(job, args, 'finished', xml=dumps(fileinfodict))
+
+    return is_success
+
+
+def _stage_out_all(job, args):  ### TO BE DEPRECATED
     """
     Order stage-out of all output files and the log file, or only the log file.
 
     :param job:
     :param args:
-    :return:
+    :return: True in case of success
     """
 
     log = get_logger(job.jobid)
@@ -640,7 +759,7 @@ def queue_monitoring(queues, traces, args):
         else:
             # stage-out log file then add the job to the failed_jobs queue
             job.stageout = "log"
-            if not _stage_out_all(job, args):
+            if not _stage_out_new(job, args):
                 logger.info("job %s failed during stage-in and stage-out of log, adding job object to failed_data_outs "
                             "queue" % job.jobid)
                 queues.failed_data_out.put(job)

--- a/pilot/info/__init__.py
+++ b/pilot/info/__init__.py
@@ -82,8 +82,8 @@ def set_info(args):
 
     logger.info('queue: %s' % args.info.queue)
     #logger.info('site: %s' % args.info.site)
-    logger.info('storages: %s' % args.info.storages)
-    logger.info('queuedata: %s' % args.info.infoservice.queuedata)
+    #logger.info('storages: %s' % args.info.storages)
+    #logger.info('queuedata: %s' % args.info.infoservice.queuedata)
 
 
 # global InfoService Instance without Job specific settings applied (singleton shared object)

--- a/pilot/info/__init__.py
+++ b/pilot/info/__init__.py
@@ -22,6 +22,7 @@ in a unified structured way to all Pilot modules by providing high-level API
 from .infoservice import InfoService
 from .jobinfo import JobInfoProvider  # noqa
 from .jobdata import JobData          # noqa
+from .filespec import FileSpec        # noqa
 
 #from .queuedata import QueueData
 

--- a/pilot/info/basedata.py
+++ b/pilot/info/basedata.py
@@ -21,6 +21,7 @@ The main reasons for such incapsulation are to
 :date: January 2018
 """
 
+import copy
 import logging
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,7 @@ class BaseData(object):
                 ## cast to required type and apply default validation
                 hvalidator = validators.get(ktype, validators.get(None))
                 if callable(hvalidator):
-                    value = hvalidator(raw, ktype, kname, defval=getattr(self, kname, None))
+                    value = hvalidator(raw, ktype, kname, defval=copy.deepcopy(getattr(self, kname, None)))
                 ## apply custom validation if defined
                 hvalidator = getattr(self, 'clean__%s' % kname, None)
                 if callable(hvalidator):

--- a/pilot/info/basedata.py
+++ b/pilot/info/basedata.py
@@ -120,7 +120,8 @@ class BaseData(object):
         try:
             return ktype(raw)
         except Exception:
-            logger.warning('failed to convert data for key=%s, raw=%s to type=%s' % (kname, raw, ktype))
+            if raw is not None:
+                logger.warning('failed to convert data for key=%s, raw=%s to type=%s, defval=%s' % (kname, raw, ktype, defval))
             return defval
 
     def clean_string(self, raw, ktype, kname=None, defval=""):

--- a/pilot/info/filespec.py
+++ b/pilot/info/filespec.py
@@ -52,6 +52,7 @@ class FileSpec(BaseData):
     ## local keys
     type = ''          # type of File: input, output of log
     replicas = None    # list of resolved input replicas
+    protocols = None   # list of preferred protocols for requested activity
     surl = ''          # source url
     turl = ''          # transfer url
     mtime = 0          # file modification time

--- a/pilot/info/jobdata.py
+++ b/pilot/info/jobdata.py
@@ -117,9 +117,9 @@ class JobData(BaseData):
     logguid = ""  # unique guid for log file                             ## TO BE DEPRECATED: moved to FileSpec (use job.logdata instead)
     noexecstrcnv = None  # server instruction to the pilot if it should take payload setup from job parameters
     outfiles = ""  # comma-separated list (string) of output files       ## TO BE DEPRECATED: moved to FileSpec (job.outdata)
-    scopein = ""  # comma-separated list (string) of input file scopes   ## TO BE DEPRECATED: moved to FileSpec (job.indata)
-    scopelog = ""  # scope for log file                                  ## TO BE DEPRECATED: moved to FileSpec (use job.logdata instead)
-    scopeout = ""  # comma-separated list (string) of output file scopes ## TO BE DEPRECATED: moved to FileSpec (use job.logdata instead)
+    #scopein = ""  # comma-separated list (string) of input file scopes   ## TO BE DEPRECATED: moved to FileSpec (job.indata)
+    #scopelog = ""  # scope for log file                                  ## TO BE DEPRECATED: moved to FileSpec (use job.logdata instead)
+    #scopeout = ""  # comma-separated list (string) of output file scopes ## TO BE DEPRECATED: moved to FileSpec (use job.logdata instead)
     swrelease = ""  # software release string
 
     # RAW data to keep backward compatible behavior for a while ## TO BE REMOVED once all job attributes will be covered
@@ -179,7 +179,7 @@ class JobData(BaseData):
         }
 
         ksources = dict([k, self.clean_listdata(data.get(k, ''), list, k, [])] for k in kmap.itervalues())
-        logger.info('ksources=%s' % str(ksources))
+        logger.debug('ksources=%s' % str(ksources))
         ret, lfns = [], set()
         for ind, lfn in enumerate(ksources.get('inFiles', [])):
             if lfn in ['', 'NULL'] or lfn in lfns:  # exclude null data and duplicates

--- a/pilot/info/jobdata.py
+++ b/pilot/info/jobdata.py
@@ -133,7 +133,7 @@ class JobData(BaseData):
                    'platform', 'piloterrordiag', 'exitmsg',
                    'infiles', 'scopein', 'ddmendpointin',       ## TO BE DEPRECATED: moved to FileSpec (job.indata)
                    'outfiles', 'scopeout', 'ddmendpointout',    ## TO BE DEPRECATED: moved to FileSpec (job.outdata)
-                   'scopelog', 'logfile', 'logguid',            ## TO BE DEPRECATED: moved to FileSpec (job.logdata)
+                   #'scopelog', 'logfile', 'logguid',            ## TO BE DEPRECATED: moved to FileSpec (job.logdata)
                    'cpuconsumptionunit', 'cpuconsumptiontime', 'homepackage', 'jobsetid', 'payload', 'processingtype',
                    'swrelease', 'zipmap', 'imagename', 'transfertype', 'datasetin', 'datasetout', 'infilesguids'],
              list: ['piloterrorcodes', 'piloterrordiags', 'workdirsizes'],
@@ -156,7 +156,7 @@ class JobData(BaseData):
 
         # DEBUG
         import pprint
-        logger.debug('Initialize Job from raw:\n%s' % pprint.pformat(data))
+        #logger.debug('Initialize Job from raw:\n%s' % pprint.pformat(data))
         #logger.debug('Final parsed Job content:\n%s' % self)
 
     def prepare_infiles(self, data):
@@ -308,11 +308,11 @@ class JobData(BaseData):
             'platform': 'cmtConfig',
             'scopein': 'scopeIn',                        ## TO BE DEPRECATED: moved to FileSpec (job.indata)
             'scopeout': 'scopeOut',                      ## TO BE DEPRECATED: moved to FileSpec
-            'scopelog': 'scopeLog',                      ## TO BE DEPRECATED: moved to FileSpec
-            'logfile': 'logFile',                        ## TO BE DEPRECATED: moved to FileSpec
+            #'scopelog': 'scopeLog',                      ## TO BE DEPRECATED: moved to FileSpec
+            #'logfile': 'logFile',                        ## TO BE DEPRECATED: moved to FileSpec
             'infiles': 'inFiles',                        ## TO BE DEPRECATED: moved to FileSpec (job.indata)
             'outfiles': 'outFiles',                      ## TO BE DEPRECATED: moved to FileSpec
-            'logguid': 'logGUID',                        ## TO BE DEPRECATED: moved to FileSpec
+            #'logguid': 'logGUID',                        ## TO BE DEPRECATED: moved to FileSpec
             'infilesguids': 'GUID',                      ## TO BE DEPRECATED: moved to FileSpec
             'attemptnr': 'attemptNr',
             'ddmendpointin': 'ddmEndPointIn',            ## TO BE DEPRECATED: moved to FileSpec (job.indata)

--- a/pilot/info/queuedata.py
+++ b/pilot/info/queuedata.py
@@ -85,7 +85,7 @@ class QueueData(BaseData):
 
         # DEBUG
         import pprint
-        logger.debug('initialize QueueData from raw:\n%s' % pprint.pformat(data))
+        #logger.debug('initialize QueueData from raw:\n%s' % pprint.pformat(data))
         logger.debug('Final parsed QueueData content:\n%s' % self)
 
     def load(self, data):

--- a/pilot/info/storagedata.py
+++ b/pilot/info/storagedata.py
@@ -38,15 +38,18 @@ class StorageData(BaseData):
     pk = 0        # unique identification number
     name = ""     # DDMEndpoint name
     type = ""     # type of Storage
+    is_deterministic = None
 
     state = None
     site = None   # ATLAS Site name
 
+    arprotocols = {}
+
     # specify the type of attributes for proper data validation and casting
     _keys = {int: ['pk'],
              str: ['name', 'state', 'site', 'type'],
-             dict: ['copytools', 'acopytools', 'astorages', 'aprotocols'],
-             bool: []
+             dict: ['copytools', 'acopytools', 'astorages', 'arprotocols'],
+             bool: ['is_deterministic']
              }
 
     def __init__(self, data):

--- a/pilot/user/atlas/common.py
+++ b/pilot/user/atlas/common.py
@@ -426,8 +426,6 @@ def update_job_data(job):  # noqa: C901
         if not dat.guid:
             dat.guid = get_guid()
             logger.info('Generated guid=%s for lfn=%s' % (dat.guid, dat.lfn))
-        if not dat.filesize:
-            dat.filesize = get_local_file_size() or 0
 
 
 def parse_jobreport_data(job_report):

--- a/pilot/user/atlas/common.py
+++ b/pilot/user/atlas/common.py
@@ -423,9 +423,9 @@ def update_job_data(job):  # noqa: C901
 
     ## validate output data (to be moved into the JobData)
     for dat in job.outdata:
-        if not dat.giud:
+        if not dat.guid:
             dat.guid = get_guid()
-            logger.info('Generated giud=%s for lfn=%s' % (dat.guid, dat.lfn))
+            logger.info('Generated guid=%s for lfn=%s' % (dat.guid, dat.lfn))
         if not dat.filesize:
             dat.filesize = get_local_file_size() or 0
 

--- a/pilot/user/atlas/common.py
+++ b/pilot/user/atlas/common.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from glob import glob
 from signal import SIGTERM, SIGUSR1
 
-from pilot.common.exception import TrfDownloadFailure
+from pilot.common.exception import TrfDownloadFailure, PilotException
 from pilot.user.atlas.setup import should_pilot_prepare_asetup, get_asetup, get_asetup_options, is_standard_atlas_job,\
     set_inds, get_analysis_trf, get_payload_environment_variables
 from pilot.user.atlas.utilities import get_memory_monitor_setup, get_network_monitor_setup, post_memory_monitor_action,\
@@ -23,7 +23,9 @@ from pilot.util.auxiliary import get_logger
 from pilot.util.constants import UTILITY_BEFORE_PAYLOAD, UTILITY_WITH_PAYLOAD, UTILITY_AFTER_PAYLOAD,\
     UTILITY_WITH_STAGEIN
 from pilot.util.container import execute
-from pilot.util.filehandling import remove
+from pilot.util.filehandling import remove, get_guid, get_local_file_size
+
+from pilot.info import FileSpec
 
 import logging
 logger = logging.getLogger(__name__)
@@ -351,7 +353,7 @@ def get_file_transfer_info(transfertype, is_a_build_job, queuedata):
     return use_copy_tool, use_direct_access, use_pfc_turl
 
 
-def update_job_data(job):
+def update_job_data(job):  # noqa: C901
     """
     This function can be used to update/add data to the job object.
     E.g. user specific information can be extracted from other job object fields. In the case of ATLAS, information
@@ -360,6 +362,11 @@ def update_job_data(job):
     :param job: job object
     :return:
     """
+
+    ## comment from Alexey:
+    ## it would be better to reallocate this logic (as well as parse metadata values)directly to Job object
+    ## since in general it's Job related part
+    ## later on once we introduce VO specific Job class (inherited from JobData) this can be easily customized
 
     stageout = "all"
 
@@ -373,7 +380,7 @@ def update_job_data(job):
             stageout = "log"
     if 'exeErrorDiag' in job.metadata:
         job.exeerrordiag = job.metadata['exeErrorDiag']
-        if job.exeerrordiag != "":
+        if job.exeerrordiag:
             logger.warning('payload failed: exeErrorDiag=%s' % job.exeerrordiag)
 
     # determine what should be staged out
@@ -382,12 +389,45 @@ def update_job_data(job):
     # extract the number of events
     job.nevents = get_number_of_events(job.metadata)
 
+    work_attributes = None
     try:
         work_attributes = parse_jobreport_data(job.metadata)
     except Exception as e:
         logger.warning('failed to parse job report: %s' % e)
-    else:
-        logger.info('work_attributes = %s' % str(work_attributes))
+
+    logger.info('work_attributes = %s' % work_attributes)
+
+    # extract output files from the job report, in case the trf has created additional (overflow) files
+    if job.metadata:
+        data = dict([e.lfn, e] for e in job.outdata)
+        extra = []
+
+        for dat in job.metadata.get('files', {}).get('output', []):
+            for fdat in dat.get('subFiles', []):
+                lfn = fdat['name']
+                if lfn not in data:  # found new entry, create filespec
+                    if not job.outdata:
+                        raise PilotException("Failed to grub data from job report: job.outdata is empty, will not be able to construct filespecs")
+                    kw = {'lfn': lfn,
+                          'scope': job.outdata[0].scope,  ## take value from 1st output file?
+                          'guid': fdat['file_guid'],
+                          'filesize': fdat['file_size'],
+                          'dataset': dat.get('dataset') or job.outdata[0].dataset  ## take value from 1st output file?
+                          }
+                    spec = FileSpec(type='output', **kw)
+                    extra.append(spec)
+
+        if extra:
+            logger.info('Found extra output files to be added for stage-out: extra=%s' % extra)
+            job.outdata.extend(extra)
+
+    ## validate output data (to be moved into the JobData)
+    for dat in job.outdata:
+        if not dat.giud:
+            dat.guid = get_guid()
+            logger.info('Generated giud=%s for lfn=%s' % (dat.guid, dat.lfn))
+        if not dat.filesize:
+            dat.filesize = get_local_file_size() or 0
 
 
 def parse_jobreport_data(job_report):

--- a/pilot/util/default.cfg
+++ b/pilot/util/default.cfg
@@ -102,7 +102,7 @@ queuedata: queuedata.json
 
 # overwrite acopytools for queuedata
 #acopytools: {'pr':['rucio']}
-#acopytools: {'pr':['gfalcopy'], 'pw':['gfalcopy']}
+#acopytools: {'pr':['rucio'], 'pw':['gfalcopy'], 'pl':['gfalcopy']}
 
 ################################
 # Payload parameters

--- a/pilot/util/default.cfg
+++ b/pilot/util/default.cfg
@@ -102,7 +102,7 @@ queuedata: queuedata.json
 
 # overwrite acopytools for queuedata
 #acopytools: {'pr':['rucio']}
-#acopytools: {'pr':['gfalcopy']}
+#acopytools: {'pr':['gfalcopy'], 'pw':['gfalcopy']}
 
 ################################
 # Payload parameters


### PR DESCRIPTION
Stage-out implementation:

- data API: `StageoutClient` implemented
- implemented base stage-out workflow taking `FileSpec` objects as an input
- upgraded stageout logic for `gfal-copy` copytool to use `FileSpec`
- reimplemented `xrdcp` copytool (stage-in+stage-out consider `FileSpecs`)

*Limitations:*
 - xrdcp copytool does not support transfer verification by checksum value (actually base mover logic/workflow should be implemented to do such validation for all the copytools affected )
 - xrdcp for stage-out has not been tested
 
Only gfal-copy+xrdcp copytools where ported to use `FileSpec` for stage-out.
All other copytools will fail.

To overwrite copytools Pilot side, please change  `default.cfg`
e.g.
```python
acopytools: {'pr':['xrdcp'], 'pw':['gfalcopy'], 'pl':['gfalcopy']}
```
https://github.com/anisyonk/pilot2/blob/ccf618ff12f9a360686bcd488399c15cfbe65567/pilot/util/default.cfg#L105
