### PR TITLE
Clean up & rucio mover implementation (stage-out)

### DIFF
--- a/pilot/info/jobdata.py
+++ b/pilot/info/jobdata.py
@@ -157,7 +157,7 @@ class JobData(BaseData):
         # DEBUG
         import pprint
         #logger.debug('Initialize Job from raw:\n%s' % pprint.pformat(data))
-        #logger.debug('Final parsed Job content:\n%s' % self)
+        logger.debug('Final parsed Job content:\n%s' % self)
 
     def prepare_infiles(self, data):
         """

--- a/pilot/info/jobdata.py
+++ b/pilot/info/jobdata.py
@@ -155,7 +155,7 @@ class JobData(BaseData):
         self.outdata, self.logdata = self.prepare_outfiles(data)
 
         # DEBUG
-        import pprint
+        #import pprint
         #logger.debug('Initialize Job from raw:\n%s' % pprint.pformat(data))
         logger.debug('Final parsed Job content:\n%s' % self)
 

--- a/pilot/info/queuedata.py
+++ b/pilot/info/queuedata.py
@@ -84,7 +84,7 @@ class QueueData(BaseData):
         self.load(data)
 
         # DEBUG
-        import pprint
+        #import pprint
         #logger.debug('initialize QueueData from raw:\n%s' % pprint.pformat(data))
         logger.debug('Final parsed QueueData content:\n%s' % self)
 

--- a/pilot/user/atlas/common.py
+++ b/pilot/user/atlas/common.py
@@ -23,7 +23,7 @@ from pilot.util.auxiliary import get_logger
 from pilot.util.constants import UTILITY_BEFORE_PAYLOAD, UTILITY_WITH_PAYLOAD, UTILITY_AFTER_PAYLOAD,\
     UTILITY_WITH_STAGEIN
 from pilot.util.container import execute
-from pilot.util.filehandling import remove, get_guid, get_local_file_size
+from pilot.util.filehandling import remove, get_guid
 
 from pilot.info import FileSpec
 


### PR DESCRIPTION
- rucio mover upgraded (consider FileSpecs for stage-out, quick implementation of checksum verification for stage-out, report back pfn/turl value)
 - clean up: deprecate plain jobdata fields (ddmendpointin, ddmendpointout, scopein, scopeout, scopelog, logfile, outfiles, logguid, datasetout)
- various fixes
