### PR TITLE
Workaround for issue with timing file.

### DIFF
--- a/pilot/resource/titan.py
+++ b/pilot/resource/titan.py
@@ -14,24 +14,12 @@ import sys
 import shutil
 
 from pilot.util.config import config
+from pilot.util.mpi import get_ranks_info
 from pilot.util.filehandling import read_json, write_json, remove
 from pilot.common.exception import FileHandlingFailure
 from jobdescription import JobDescription
 
 logger = logging.getLogger(__name__)
-
-
-def get_rank():
-    rank = None
-    try:
-        from mpi4py import MPI
-        comm = MPI.COMM_WORLD
-        rank = comm.Get_rank()
-        max_rank = comm.Get_size()
-        logger.info("Got rank {0} from {1}".format(rank, max_rank))
-    except ImportError:
-        logger.info("No mpi4py found.")
-    return rank
 
 
 def get_job(harvesterpath):
@@ -48,7 +36,7 @@ def get_job(harvesterpath):
         logger.info("File with PanDA IDs is missed. Nothing to execute.")
         return job, rank
     harvesterpath = os.path.abspath(harvesterpath)
-    rank = get_rank()
+    rank, max_ranks = get_ranks_info()
     pandaids = read_json(pandaids_list_filename)
     logger.info('Got {0} job ids'.format(len(pandaids)))
     pandaid = pandaids[rank]

--- a/pilot/util/mpi.py
+++ b/pilot/util/mpi.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Danila Oleynik, danila.oleynik@cern.ch, 2018
+
+# Note: The Pilot 2 utilities to provide MPI related functionality through mpi4py
+# Required for HPC workflow where Pilot 2 acts like an MPI application
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def get_ranks_info():
+    """
+    Return current MPI rank and number of ranks
+    None, None - if MPI environment is not available
+     """
+    rank = None
+    max_rank = None
+    try:
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        rank = comm.Get_rank()
+        max_rank = comm.Get_size()
+    except ImportError:
+        logger.info("No mpi4py found.")
+
+    return rank, max_rank

--- a/pilot/util/timing.py
+++ b/pilot/util/timing.py
@@ -14,6 +14,7 @@ import os
 
 from pilot.util.auxiliary import get_logger
 from pilot.util.config import config
+from pilot.util.mpi import get_ranks_info
 from pilot.util.constants import PILOT_T0, PILOT_PRE_GETJOB, PILOT_POST_GETJOB, PILOT_PRE_SETUP, PILOT_POST_SETUP, \
     PILOT_PRE_STAGEIN, PILOT_POST_STAGEIN, PILOT_PRE_PAYLOAD, PILOT_POST_PAYLOAD, PILOT_PRE_STAGEOUT, \
     PILOT_POST_STAGEOUT, PILOT_PRE_FINAL_UPDATE, PILOT_POST_FINAL_UPDATE, PILOT_END_TIME
@@ -31,8 +32,11 @@ def read_pilot_timing():
     """
 
     pilot_timing_dictionary = {}
-
-    path = os.path.join(os.environ.get('PILOT_HOME', ''), config.Pilot.timing_file)
+    timing_file = config.Pilot.timing_file
+    rank, max_ranks = get_ranks_info()
+    if rank is not None:
+        timing_file += '_{0}'.format(rank)
+    path = os.path.join(os.environ.get('PILOT_HOME', ''), timing_file)
     if os.path.exists(path):
         pilot_timing_dictionary = read_json(path)
 
@@ -47,7 +51,11 @@ def write_pilot_timing(pilot_timing_dictionary):
     :return:
     """
 
-    path = os.path.join(os.environ.get('PILOT_HOME', ''), config.Pilot.timing_file)
+    timing_file = config.Pilot.timing_file
+    rank, max_ranks = get_ranks_info()
+    if rank is not None:
+        timing_file += '_{0}'.format(rank)
+    path = os.path.join(os.environ.get('PILOT_HOME', ''), timing_file)
     if write_json(path, pilot_timing_dictionary):
         logger.debug('updated pilot timing dictionary: %s' % (path))
     else:


### PR DESCRIPTION
The current implementation of collecting of Pilot timing data in the JSON file does not work well for HPC workflow, where Pilot acts like MPI application, and each rank (copy of application) starts to re-write the same file.   
Workaround allows to have own file per each rank, but it will not work well enough on a big scale (few hundred or thousands of nodes).    