### PR TITLE
fix rucio import error

### DIFF
--- a/pilot/copytool/rucio.py
+++ b/pilot/copytool/rucio.py
@@ -9,6 +9,8 @@
 # - Alexey Anisenkov, anisyonk@cern.ch, 2018
 # - Paul Nilsson, paul.nilsson@cern.ch, 2018
 
+from __future__ import absolute_import
+
 import os
 import json
 import logging


### PR DESCRIPTION
 - fix name clashing with `rucio` import