### PR TITLE
infosys cleanup (retire old queries to AGIS)

### DIFF
--- a/pilot/control/job.py
+++ b/pilot/control/job.py
@@ -454,22 +454,18 @@ def get_dispatcher_dictionary(args):
     :returns: dictionary prepared for the dispatcher getJob operation.
     """
 
-    #_diskspace = get_disk_space(args.location.queuedata)
-
-    ## passing here the queuedata is redundant since it's available
-    ## globally via pilot.info.infosys
-    ## kept for a while as "wrong" example .. to be cleaned soon
-    _diskspace = get_disk_space(args.info.infoservice.queuedata)
+    _diskspace = get_disk_space(infosys.queuedata)
 
     _mem, _cpu, _disk = collect_workernode_info()
+
     _nodename = get_node_name()
 
     # override for RC dev pilots
     job_label = get_job_label(args)
 
     data = {
-        'siteName': args.resource,
-        'computingElement': args.location.queue,
+        'siteName': args.resource,   ## replace it with `infosys.queuedata.resource` to remove redundant '-r' option of pilot.py
+        'computingElement': args.queue,
         'prodSourceLabel': job_label,
         'diskSpace': _diskspace,
         'workingGroup': args.working_group,

--- a/pilot/info/__init__.py
+++ b/pilot/info/__init__.py
@@ -34,7 +34,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def set_info(args):
+def set_info(args):   ## should be DEPRECATED: use `infosys.init(queuename)`
     """
     Set up all necessary site information for given PandaQueue name.
     Resolve everything from the specified queue name (passed via `args.queue`)

--- a/pilot/info/extinfo.py
+++ b/pilot/info/extinfo.py
@@ -126,6 +126,7 @@ class ExtInfoProvider(DataLoader):
                    # FIX ME LATER: move hardcoded urls to the Config?
                    'PANDA': {'url': 'http://pandaserver.cern.ch:25085/cache/schedconfig/%s.all.json' % pandaqueues[0],
                              'nretry': 3,
+                             'sleep_time': lambda: 15 + random.randint(0, 30),  # max sleep time 45 seconds between retries
                              'cache_time': 3 * 60 * 60,  # 3 hours,
                              'fname': os.path.join(cache_dir, 'queuedata.json'),
                              'parser': jsonparser_panda

--- a/pilot/info/infoservice.py
+++ b/pilot/info/infoservice.py
@@ -86,7 +86,7 @@ class InfoService(object):
 
         self.queuedata = self.resolve_queuedata(self.pandaqueue)
 
-        if not self.queuedata:
+        if not self.queuedata or not self.queuedata.name:
             raise QueuedataFailure("Failed to resolve queuedata for queue=%s, wrong PandaQueue name?" % self.pandaqueue)
 
         self.resolve_storage_data()  ## prefetch details for all storages

--- a/pilot/info/queuedata.py
+++ b/pilot/info/queuedata.py
@@ -41,6 +41,7 @@ class QueueData(BaseData):
     # ## incomplete list of attributes .. to be extended once becomes used
 
     name = ""       # Name of Panda Queue
+    resource = ""   # Name of Panda Resource
     appdir = ""     #
     catchall = ""   #
 
@@ -73,7 +74,7 @@ class QueueData(BaseData):
     # specify the type of attributes for proper data validation and casting
     _keys = {int: ['timefloor', 'maxwdir', 'pledgedcpu', 'es_stageout_gap',
                    'corecount', 'maxrss', 'maxtime'],
-             str: ['name', 'appdir', 'catchall', 'platform', 'container_options', 'container_type',
+             str: ['name', 'resource', 'appdir', 'catchall', 'platform', 'container_options', 'container_type',
                    'state', 'site'],
              dict: ['copytools', 'acopytools', 'astorages', 'aprotocols'],
              bool: ['direct_access_lan', 'direct_access_wan']
@@ -107,6 +108,7 @@ class QueueData(BaseData):
 
         kmap = {
             'name': 'nickname',
+            'resource': 'panda_resource',
             'platform': 'cmtconfig',
             'site': ('atlas_site', 'gstat'),
             'es_stageout_gap': 'zip_time_gap',

--- a/pilot/util/information.py
+++ b/pilot/util/information.py
@@ -14,6 +14,8 @@
 # sites, storages, and queues from AGIS and tries to locally cache them.
 # No cache update is involved, just remove the .cache files.
 
+## THIS FILE CAN BE COMPLETELY REMOVED
+
 import collections
 import hashlib
 import json
@@ -30,7 +32,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def set_location(args, site=None):
+def set_location(args, site=None):  ## TO BE DEPRECATED -- not used
     """
     Set up all necessary site information.
     Resolve everything from the specified queue name, and fill extra lookup structure.
@@ -274,7 +276,7 @@ def load_url_data(url, fname=None, cache_time=0, nretry=3, sleeptime=60):
                                (url, e, fname))
                 # will try to use old cache below
                 if trial < nretry - 1:
-                    logger.info("will try again after %ss.." % sleeptime)
+                    logger.info(" -- DEPRECATED-- will try again after %ss.." % sleeptime)
                     from time import sleep
                     sleep(sleeptime)
 


### PR DESCRIPTION
Various updates and clean up:

- set dynamic sleep time between retries from Panda schedconfig source
-  add `QueueData.resource` field to store `panda_resource` value (for further usage instead of values passed into `pilot.py` command line options)
 - deprecate `pilot.util.information.set_location`, the file `pilot.util.information` can be removed now
 - explicitly initialize info service instance inside `pilot.py` (avoid redundant wrappers), `pilot.info.set_info` can be retired as well.

In general, (currently being mandatory) input options like '-r' (for PandaResource name), '-s' (for ATLAS Site or PandaSite? name or it's just an alias to PandaResource?) can be retired, and corresponding values can be replaced with values automatically resolved on fly from queuedata like `infosys.queuedata.resource` or `infosys.queuedata.site`

Paul, can you please run the updates with real test jobs. 
I only tested in emulated mode, however it should work well.