### PR TITLE
Timeout decorator update

### DIFF
--- a/pilot/util/timer.py
+++ b/pilot/util/timer.py
@@ -18,6 +18,7 @@ Timer stops execution of wrapped function if it reaches the limit of provided ti
 
 import os
 import signal
+import sys
 
 import threading
 import multiprocessing
@@ -57,8 +58,9 @@ class TimedThread(object):
 
         try:
             ret = (True, func(*args, **kwargs))
-        except Exception as e:
-            ret = (False, e)
+        except Exception:
+            ret = (False, sys.exc_info())
+
         self.result = ret
 
         return ret
@@ -86,7 +88,7 @@ class TimedThread(object):
         if ret[0]:
             return ret[1]
         else:
-            raise ret[1]
+            raise ret[1][0], ret[1][1], ret[1][2]
 
 
 class TimedProcess(object):

--- a/pilot/util/timer.py
+++ b/pilot/util/timer.py
@@ -140,7 +140,7 @@ class TimedProcess(object):
         if ret[0]:
             return ret[1]
         else:
-            raise ret[1]
+            raise ret[1][0], ret[1][1], ret[1][2]
 
 
 if getattr(os, 'fork', None):


### PR DESCRIPTION
 - preserve/expose original back trace stack on exception in decorated function
