### PR TITLE
Avoid stage out to nucleus

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -662,6 +662,57 @@ class StageOutClient(StagingClient):
 
         return protocols
 
+    def prepare_destinations(self, files, activities):
+        """
+            Resolve destination RSE (filespec.ddmendpoint) for each entry from `files` according to requested `activities`
+            Apply Pilot-side logic to choose proper destination
+            :param files: list of FileSpec objects to be processed
+            :param activities: ordered list of activities to be used to resolve astorages
+            :return: updated fspec entries
+        """
+
+        if not self.infosys.queuedata:  ## infosys is not initialized: not able to fix destination if need, nothing to do
+            return files
+
+        if isinstance(activities, (str, unicode)):
+            activities = [activities]
+
+        if not activities:
+            raise PilotException("Failed to resolve destination: passed empty activity list. Internal error.",
+                                 code=ErrorCodes.INTERNALPILOTPROBLEM, state='INTERNAL_ERROR')
+
+        astorages = self.infosys.queuedata.astorages or {}
+
+        storages = None
+        activity = activities[0]
+        for a in activities:
+            storages = astorages.get(a, {})
+            if storages:
+                break
+
+        if not storages:
+            raise PilotException("Failed to resolve destination: no associated storages defined for activity=%s (%s)"
+                                 % (activity, ','.join(activities)), code=ErrorCodes.NOSTORAGE, state='NO_ASTORAGES_DEFINED')
+
+        # take the fist choice for now, extend the logic later if need
+        ddm = storages[0]
+
+        self.logger.info("[prepare_destinations][%s]: allowed (local) destinations: %s" % (activity, storages))
+        self.logger.info("[prepare_destinations][%s]: resolved default destination ddm=%s" % (activity, ddm))
+
+        for e in files:
+            if not e.ddmendpoint:  ## no preferences => use default destination
+                self.logger.info("[prepare_destinations][%s]: fspec.ddmendpoint is not set for lfn=%s"
+                                 " .. will use default ddm=%s as (local) destination" % (activity, e.lfn, ddm))
+                e.ddmendpoint = ddm
+            elif e.ddmendpoint not in storages:  ## fspec.ddmendpoint is not in associated storages => assume it as final (non local) alternative destination
+                self.logger.info("[prepare_destinations][%s]: Requested fspec.ddmendpoint=%s is not in the list of allowed (local) destinations"
+                                 " .. will consider default ddm=%s for transfer and tag %s as alt. location" % (activity, e.ddmendpoint, ddm, e.ddmendpoint))
+                e.ddmendpoint = ddm
+                e.ddmendpoint_alt = e.ddmendpoint  ###  consider me later
+
+        return files
+
     @classmethod
     def get_path(self, scope, lfn, prefix='rucio'):
         """

--- a/pilot/common/errorcodes.py
+++ b/pilot/common/errorcodes.py
@@ -33,6 +33,7 @@ class ErrorCodes:
     QUEUEDATA = 1116
     QUEUEDATANOTOK = 1117
     OUTPUTFILETOOLARGE = 1124
+    NOSTORAGE = 1133
     STAGEOUTFAILED = 1137
     PUTMD5MISMATCH = 1141
     CHMODTRF = 1143
@@ -129,6 +130,7 @@ class ErrorCodes:
         QUEUEDATA: "Pilot could not download queuedata",
         QUEUEDATANOTOK: "Pilot found non-valid queuedata",
         OUTPUTFILETOOLARGE: "Output file too large",
+        NOSTORAGE: "Fetching default storage failed: no activity related storage defined",
         STAGEOUTFAILED: "Failed to stage-out file",
         PUTMD5MISMATCH: "md5sum mismatch on output file",
         GETMD5MISMATCH: "md5sum mismatch on input file",

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -574,7 +574,7 @@ def _do_stageout(job, xdata, activity, title):
 
     :param job: job object.
     :param xdata: list of FileSpec objects.
-    :param activity:
+    :param activity: copytool activity or preferred list of activities to resolve copytools
     :param title: type of stage-out (output, log) (string).
     :return: True in case of success transfers
     """
@@ -596,8 +596,8 @@ def _do_stageout(job, xdata, activity, title):
 
     try:
         client = StageOutClient(job.infosys, logger=log, trace_report=trace_report)
-        kwargs = dict(workdir=job.workdir, cwd=job.workdir, usecontainer=False, job=job)  #, mode='stage-out')
-
+        kwargs = dict(workdir=job.workdir, cwd=job.workdir, usecontainer=False, job=job, mode='stage-out')
+        client.prepare_destinations(xdata, activity)  ## FIX ME LATER: split activities: for astorages and for copytools (to unify with ES workflow)
         client.transfer(xdata, activity, **kwargs)
     except PilotException as error:
         import traceback
@@ -652,7 +652,7 @@ def _stage_out_new(job, args):
         job.stageout = 'log'
 
     if job.stageout != 'log':  ## do stage-out output files
-        if not _do_stageout(job, job.outdata, ['pw', 'w'], 'output'):
+        if not _do_stageout(job, job.outdata, ['pw', 'w'], title='output'):
             is_success = False
             log.warning('transfer of output file(s) failed')
 
@@ -667,7 +667,7 @@ def _stage_out_new(job, args):
         logfile = job.logdata[0]
         create_log(job, logfile, 'tarball_PandaJob_%s_%s' % (job.jobid, job.infosys.pandaqueue))
 
-        if not _do_stageout(job, [logfile], ['pl', 'pw', 'w'], 'log'):
+        if not _do_stageout(job, [logfile], ['pl', 'pw', 'w'], title='log'):
             is_success = False
             log.warning('log transfer failed')
             job.status['LOG_TRANSFER'] = LOG_TRANSFER_FAILED


### PR DESCRIPTION
- stage out logic updates: ignore the nucleus destination (use a default destination from the `astorages`).

 (port `prepare_destinations` logic from Pilot1)

fast test shown that in general workflow works:  https://bigpanda.cern.ch/job?pandaid=4284138141

to be tested with real job requesting store to the nucleus