### PR TITLE
StorageData overwrite (customize and prioritize protocols to be used for transfers at job level)

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -768,7 +768,7 @@ class StageOutClient(StagingClient):
         surl = protocol.get('endpoint', '') + os.path.join(protocol.get('path', ''), self.get_path(fspec.scope, fspec.lfn))
         return {'surl': surl}
 
-    def transfer_files(self, copytool, files, activity, **kwargs):
+    def transfer_files(self, copytool, files, activity, **kwargs):  # noqa: C901
         """
             Automatically stage out files using the selected copy tool module.
 

--- a/pilot/info/extinfo.py
+++ b/pilot/info/extinfo.py
@@ -197,7 +197,6 @@ class ExtInfoProvider(DataLoader):
     def resolve_storage_data(self, ddmendpoints=[]):
         """
             Resolve final DDM Storages details by given names (DDMEndpoint)
-            (primary data provided by PanDA merged with overall queue details from AGIS)
 
             :param ddmendpoints: list of ddmendpoint names
             :return: dict of settings for given DDMEndpoint as a key

--- a/pilot/info/jobdata.py
+++ b/pilot/info/jobdata.py
@@ -95,6 +95,8 @@ class JobData(BaseData):
     t0 = None                      # payload startup time
 
     overwrite_queuedata = {}       # custom settings extracted from job parameters (--overwriteQueueData) to be used as master values for `QueueData`
+    overwrite_storagedata = {}     # custom settings extracted from job parameters (--overwriteStorageData) to be used as master values for `StorageData`
+
     zipmap = ""                    # ZIP MAP values extracted from jobparameters
     imagename = ""                 # user defined container image name extracted from job parameters
 
@@ -443,8 +445,10 @@ class JobData(BaseData):
         ret = re.sub(r"--overwriteQueuedata={.*?}", "", value)
 
         ## extract overwrite options
-        options, ret = self.parse_args(ret, {'--overwriteQueueData': lambda x: ast.literal_eval(x) if x else {}}, remove=True)
+        options, ret = self.parse_args(ret, {'--overwriteQueueData': lambda x: ast.literal_eval(x) if x else {},
+                                             '--overwriteStorageData': lambda x: ast.literal_eval(x) if x else {}}, remove=True)
         self.overwrite_queuedata = options.get('--overwriteQueueData', {})
+        self.overwrite_storagedata = options.get('--overwriteStorageData', {})
 
         #logger.debug('ret(1) = %s' % ret)
         #ret = ret.replace("\'\"\'\"\'", '\\\"')

--- a/pilot/info/jobinfo.py
+++ b/pilot/info/jobinfo.py
@@ -50,6 +50,7 @@ class JobInfoProvider(object):
             :return: dict of settings for given PandaQueue as a key
         """
 
+        # use following keys from job definition
         # keys format: [(inputkey, outputkey), inputkey2]
         # outputkey is the name of external source attribute
         keys = [('platform', 'cmtconfig')]
@@ -69,3 +70,19 @@ class JobInfoProvider(object):
         logger.info('queuedata: following keys will be overwritten by Job values: %s' % data)
 
         return {pandaqueue: data}
+
+    def resolve_storage_data(self, ddmendpoints=[], **kwargs):
+        """
+            Resolve Job specific settings for storage data (including data passed via --overwriteStorageData)
+            :return: dict of settings for requested DDMEndpoints with ddmendpoin as a key
+        """
+
+        data = {}
+
+        ## use job.overwrite_storagedata as a master source
+        master_data = self.job.overwrite_storagedata or {}
+        data.update((k, v) for k, v in master_data.iteritems() if k in set(ddmendpoints or master_data) & set(master_data))
+
+        logger.info('storagedata: following data extracted from Job definition will be used: %s' % data)
+
+        return data

--- a/pilot/info/queuedata.py
+++ b/pilot/info/queuedata.py
@@ -51,11 +51,14 @@ class QueueData(BaseData):
 
     copytools = None
     acopytools = None
-    acopytools_schemas = {}  ## allowed protocol schemas for requested copytool/activity
-                             ## if dict value (key=activity) is a list, then schemas considered the same for all allowed copytools
-                             ## in case of dict-based value, it specifies allowed schemas per copytool for given activity
-                             ## e.g. {'pr':['root', 'srm'], 'pw':['webdav'], 'default':['root']}
-                             ##      {'pr': {'gfalcopy':['webdav'], 'pw':{'lsm':['root']}}}
+
+    ## allowed protocol schemas for requested copytool/activity
+    ## if passed value (per activity) is a list, then given schemas will be used for all allowed copytools
+    ## in case of dict-based value, it specifies allowed schemas per copytool for given activity
+    ## e.g. {'pr':['root', 'srm'], 'pw':['webdav'], 'default':['root']}
+    ##      {'pr': {'gfalcopy':['webdav'], 'pw':{'lsm':['root']}}}
+    acopytools_schemas = {}
+
     astorages = None
     aprotocols = None
 


### PR DESCRIPTION
`pilot.infosys` updates:

-  implemented functionality to customize/overwrite `StorageData` settings with values coming from job parameter (using `--overwriteStorageData` option), in particular to overwrite protocol endpoint to be used for stage-out
- support also customization of protocol  types/schemes to be used  for required activity/copytool using new `acopytools_schemas` settings of `QueueData` that can also be overwritten by Job params (using `--overwriteQueueData` option)

`acopytools_schemas`  format:

```
acopytools_schemas = {}  
## allowed protocol schemas for requested copytool/activity
## if passed value (per activity) is a list, then given schemas will be used for all allowed copytools
## in case of dict-based value, it specifies allowed schemas per copytool for given activity
## e.g. {'pr':['root', 'srm'], 'pw':['webdav'], 'default':['root']}
##      {'pr': {'gfalcopy':['srm'], 'pw':{'lsm':['root']}, 'pl':['webdav']}
```

Examples of `overwriteQueueData`  + `overwriteStorageData` options for Job params:
given example enforces to use `gsiftp` protocol for stage-in  (for any copytool configured for given PQ if copytool supports the protocol), `webdav` to store logs and `srm` or `webdav` for stage-out when `lsm` is used for transfers.
Plus the example also shows how we can overwrite protocol endpoint (`arprotocols`) for stage-out (+ in principle for stage-out logs as well) for given ddmendpoint.

`--overwriteQueueData "{'allowfax':False, 'acopytools_schemas':{'pr':['gsiftp'], 'pw':{'lsm':['srm', 'webdav']}, 'default':['root'], 'pl':['webdav']}}" --overwriteStorageData "{'AGLT2_DATADISK':{'arprotocols':{'w':[{'endpoint': 'root://xrootd.aglt2.org:1094','flavour': 'XROOTD', 'id': 259, 'path': '//pnfs/aglt2.org/atlasdatadisk/rucio/'}]}}, 'CERN-PROD_DATADISK_XX':{}}"
`

in current pilot implementation it's not possible to use custom/arbitrary  protocol for stage in since Pilot takes replica from Rucio as is.