### PR TITLE
resolve to original path before symlinking

### DIFF
--- a/pilot/copytool/mv.py
+++ b/pilot/copytool/mv.py
@@ -206,7 +206,9 @@ def symlink(source, destination):
     :return: exit_code, stdout, stderr
     """
 
-    executable = ['/usr/bin/env', 'ln', '-s', source, destination]
+    # resolve canonical path
+    realsource = os.path.realpath(source)
+    executable = ['/usr/bin/env', 'ln', '-s', realsource, destination]
     cmd = ' '.join(executable)
     exit_code, stdout, stderr = execute(cmd)
 


### PR DESCRIPTION
The previous solution of `ln -sr` doesn't work on SLC6 because the `-r` option doesn't exist in the version of ln there. This new solution using `os.path.realpath` should work on all OS and python versions.