### PR TITLE
Timeout decorator fix

### DIFF
--- a/pilot/util/timer.py
+++ b/pilot/util/timer.py
@@ -140,7 +140,7 @@ class TimedProcess(object):
         if ret[0]:
             return ret[1]
         else:
-            raise ret[1][0], ret[1][1], ret[1][2]
+            raise ret[1]
 
 
 if getattr(os, 'fork', None):


### PR DESCRIPTION
`TimedProcess` bugfix: properly propagate exception in case of function failure

**Note**: current implementation does not preserve original stack trace on exception: to be implemented separately.