### PR TITLE
Timeout decorator: print original traceback in stderr

### DIFF
--- a/pilot/util/timer.py
+++ b/pilot/util/timer.py
@@ -16,10 +16,13 @@ Timer stops execution of wrapped function if it reaches the limit of provided ti
 :date: March 2018
 """
 
+from __future__ import print_function
+
 import os
 import signal
 import sys
 
+import traceback
 import threading
 import multiprocessing
 
@@ -97,6 +100,7 @@ class TimedProcess(object):
         (completely isolated memory space)
         In default python implementation multiprocessing considers (c)pickle as serialization backend
         which is not able properly (requires a hack) to pickle local and decorated functions (affects Windows only)
+        Traceback data is printed to stderr
     """
 
     def __init__(self, timeout):
@@ -114,6 +118,8 @@ class TimedProcess(object):
                 ret = func(*args, **kwargs)
                 queue.put((True, ret))
             except Exception as e:
+                print('Exception occured while executing %s' % func, file=sys.stderr)
+                traceback.print_exc(file=sys.stderr)
                 queue.put((False, e))
 
         queue = multiprocessing.Queue(1)


### PR DESCRIPTION
Thread-based implementation of the timer (`TimedProcess`): expose original traceback in `stderr` on exception.

**Note**: since `traceback` instance can not be pickled in python by default (so that it's kind of a challenge to re-raise exception occurred  in different thread with original traceback instance) I think that exposing traceback details in `stderr` will be appropriate enough solution for checking details inside the log without overcomplicating  implementation and introducing extra dependencies to external package like `python-tblib` that allows to pickle tracebacks.