### PR TITLE
WIP: Data API updates, unify ES StagingClients

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -18,7 +18,6 @@ import logging
 import time
 
 from pilot.info import infosys
-from pilot.info.storageactivitymaps import get_ddm_activity
 from pilot.common.exception import PilotException, ErrorCodes, SizeTooLarge, NoLocalSpace, ReplicasNotFound
 from pilot.util.filehandling import calculate_checksum
 from pilot.util.math import convert_mb_to_b
@@ -109,6 +108,48 @@ class StagingClient(object):
                 if replica and (not schema or replica.startswith('%s://' % schema)):
                     return replica
 
+    def prepare_sources(self, files, activities=None):
+        """
+            Customize/prepare source data for each entry in `files` optionally checking data for requested `activities`
+            (custom StageClient could extend the logic if need)
+            :param files: list of `FileSpec` objects to be processed
+            :param activities: string or ordered list of activities to resolve `astorages` (optional)
+            :return: None
+        """
+
+        return
+
+    def prepare_inputddms(self, files, activities=None):
+        """
+            Populates filespec.inputddms for each entry from `files` list
+            :param files: list of `FileSpec` objects
+            :param activities: sting or ordered list of activities to resolve astorages (optional)
+            :return: None
+        """
+
+        activities = activities or 'read_lan'
+        if isinstance(activities, basestring):
+            activities = [activities]
+
+        astorages = self.infosys.queuedata.astorages if self.infosys and self.infosys.queuedata else {}
+
+        storages = []
+        for a in activities:
+            storages = astorages.get(a, [])
+            if storages:
+                break
+
+        #activity = activities[0]
+        #if not storages:  ## ignore empty astorages
+        #    raise PilotException("Failed to resolve input sources: no associated storages defined for activity=%s (%s)"
+        #                         % (activity, ','.join(activities)), code=ErrorCodes.NOSTORAGE, state='NO_ASTORAGES_DEFINED')
+
+        for fdat in files:
+            if not fdat.inputddms:
+                fdat.inputddms = storages
+            if not fdat.inputddms and fdat.ddmendpoint:
+                fdat.inputddms = [fdat.ddmendpoint]
+
     def resolve_replicas(self, files):  # noqa: C901
         """
             Populates filespec.replicas for each entry from `files` list
@@ -117,8 +158,7 @@ class StagingClient(object):
             :return: `files`
         """
 
-        logger = self.logger  ## the function could be static if logger will be moved outside
-
+        logger = self.logger
         xfiles = []
         #ddmconf = self.infosys.resolve_storage_data()
 
@@ -131,11 +171,6 @@ class StagingClient(object):
 
             #fdat.accessmode = 'copy'        ### quick hack to avoid changing logic below for DIRECT access handling  ## REVIEW AND FIX ME LATER
             #fdat.allowremoteinputs = False  ### quick hack to avoid changing logic below for DIRECT access handling  ## REVIEW AND FIX ME LATER
-
-            if not fdat.inputddms and self.infosys.queuedata:
-                fdat.inputddms = self.infosys.queuedata.astorages.get('pr', {})  ## FIX ME LATER: change to proper activity=read_lan
-            if not fdat.inputddms and fdat.ddmendpoint:
-                fdat.inputddms = [fdat.ddmendpoint]
             xfiles.append(fdat)
 
         if not xfiles:  # no files for replica look-up
@@ -318,9 +353,6 @@ class StagingClient(object):
         if 'default' not in activity:
             activity.append('default')
 
-        # stage-in/out?
-        #mode = kwargs.get('mode', '')
-
         copytools = None
         for aname in activity:
             copytools = self.acopytools.get(aname)
@@ -330,6 +362,18 @@ class StagingClient(object):
         if not copytools:
             raise PilotException('failed to resolve copytool by preferred activities=%s, acopytools=%s' %
                                  (activity, self.acopytools))
+
+        # populate inputddms if need
+        self.prepare_inputddms(files)
+
+        # initialize ddm_activity name for requested files if not set
+        for fspec in files:
+            if fspec.ddm_activity:  # skip already initialized data
+                continue
+            if self.mode == 'stage-in':
+                fspec.ddm_activity = filter(None, ['read_lan' if fspec.ddmendpoint in fspec.inputddms else None, 'read_wan'])
+            else:
+                fspec.ddm_activity = filter(None, ['write_lan' if fspec.ddmendpoint in fspec.inputddms else None, 'write_wan'])
 
         result, caught_errors = None, []
 
@@ -395,6 +439,95 @@ class StagingClient(object):
 
         self.logger.debug('result=%s' % str(result))
         return result
+
+    def require_protocols(self, files, copytool, activity):
+        """
+            Populates fspec.protocols and fspec.turl for each entry in `files` according to preferred fspec.ddm_activity
+            :param files: list of `FileSpec` objects
+            :param activity: str or ordered list of transfer activity names to resolve acopytools related data
+            :return: None
+        """
+
+        allowed_schemas = getattr(copytool, 'allowed_schemas', None)
+
+        if self.infosys and self.infosys.queuedata:
+            copytool_name = copytool.__name__.rsplit('.', 1)[-1]
+            allowed_schemas = self.infosys.queuedata.resolve_allowed_schemas(activity, copytool_name) or allowed_schemas
+
+        files = self.resolve_protocols(files)
+        ddmconf = self.infosys.resolve_storage_data()
+
+        for fspec in files:
+
+            protocols = self.resolve_protocol(fspec, allowed_schemas)
+            if not protocols:  #  no protocols found
+                error = 'Failed to resolve protocol for file=%s, allowed_schemas=%s, fspec=%s' % (fspec.lfn, allowed_schemas, fspec)
+                self.logger.error("resolve_protocol: %s" % error)
+                raise PilotException(error, code=ErrorCodes.NOSTORAGEPROTOCOL)
+
+            # take first available protocol for copytool: FIX ME LATER if need (do iterate over all allowed protocols?)
+            protocol = protocols[0]
+
+            self.logger.info("Resolved protocol to be used for transfer lfn=%s: data=%s" % (protocol, fspec.lfn))
+
+            resolve_surl = getattr(copytool, 'resolve_surl', None)
+            if not callable(resolve_surl):
+                resolve_surl = self.resolve_surl
+
+            r = resolve_surl(fspec, protocol, ddmconf)  ## pass ddmconf for possible custom look up at the level of copytool
+            if r.get('surl'):
+                fspec.turl = r['surl']
+            if r.get('ddmendpoint'):
+                fspec.ddmendpoint = r['ddmendpoint']
+
+    def resolve_protocols(self, files):
+        """
+            Populates filespec.protocols for each entry from `files` according to preferred `fspec.ddm_activity` value
+            :param files: list of `FileSpec` objects
+            fdat.protocols = [dict(endpoint, path, flavour), ..]
+            :return: `files`
+        """
+
+        ddmconf = self.infosys.resolve_storage_data()
+
+        for fdat in files:
+            ddm = ddmconf.get(fdat.ddmendpoint)
+            if not ddm:
+                error = 'Failed to resolve output ddmendpoint by name=%s (from PanDA), please check configuration.' % fdat.ddmendpoint
+                self.logger.error("resolve_protocols: %s, fspec=%s" % (error, fdat))
+                raise PilotException(error, code=ErrorCodes.NOSTORAGE)
+
+            protocols = []
+            for aname in fdat.ddm_activity:
+                protocols = ddm.arprotocols.get(aname)
+                if protocols:
+                    break
+
+            fdat.protocols = protocols
+
+        return files
+
+    @classmethod
+    def resolve_protocol(self, fspec, allowed_schemas=None):
+        """
+            Resolve protocols according to allowed schema
+            :param fspec: `FileSpec` instance
+            :param allowed_schemas: list of allowed schemas or any if None
+            :return: list of dict(endpoint, path, flavour)
+        """
+
+        if not fspec.protocols:
+            return []
+
+        protocols = []
+
+        allowed_schemas = allowed_schemas or [None]
+        for schema in allowed_schemas:
+            for pdat in fspec.protocols:
+                if schema is None or pdat.get('endpoint', '').startswith("%s://" % schema):
+                    protocols.append(pdat)
+
+        return protocols
 
 
 class StageInClient(StagingClient):
@@ -549,6 +682,10 @@ class StageInClient(StagingClient):
                 self.logger.info("[stage-in] found replica to be used for lfn=%s: ddmendpoint=%s, pfn=%s" %
                                  (fspec.lfn, fspec.ddmendpoint, fspec.turl))
 
+        # prepare files (resolve protocol/transfer url)
+        if getattr(copytool, 'require_input_protocols', False) and files:
+            self.require_protocols(files, copytool, activity)
+
         if not copytool.is_valid_for_copy_in(files):
             msg = 'input is not valid for transfers using copytool=%s' % copytool
             self.logger.warning(msg)
@@ -626,57 +763,6 @@ class StageInClient(StagingClient):
 class StageOutClient(StagingClient):
 
     mode = "stage-out"
-
-    def resolve_protocols(self, files, activity):
-        """
-            Populates filespec.protocols for each entry from `files` according to requested `activity`
-            :param files: list of `FileSpec` objects
-            :param activity: ordered list of preferred activity names to resolve SE protocols
-            fdat.protocols = [dict(endpoint, path, flavour), ..]
-            :return: `files`
-        """
-
-        ddmconf = self.infosys.resolve_storage_data()
-
-        if isinstance(activity, basestring):
-            activity = [activity]
-
-        for fdat in files:
-            ddm = ddmconf.get(fdat.ddmendpoint)
-            if not ddm:
-                raise Exception("Failed to resolve output ddmendpoint by name=%s (from PanDA), please check configuration. fdat=%s" % (fdat.ddmendpoint, fdat))
-
-            protocols = []
-            for aname in activity:
-                aname = get_ddm_activity(aname)
-                protocols = ddm.arprotocols.get(aname)
-                if protocols:
-                    break
-
-            fdat.protocols = protocols
-
-        return files
-
-    def resolve_protocol(self, fspec, allowed_schemas=None):
-        """
-            Resolve protocols according to allowed schema
-            :param fspec: `FileSpec` instance
-            :param allowed_schemas: list of allowed schemas or any if None
-            :return: list of dict(endpoint, path, flavour)
-        """
-
-        if not fspec.protocols:
-            return []
-
-        protocols = []
-
-        allowed_schemas = allowed_schemas or [None]
-        for schema in allowed_schemas:
-            for pdat in fspec.protocols:
-                if schema is None or pdat.get('endpoint', '').startswith("%s://" % schema):
-                    protocols.append(pdat)
-
-        return protocols
 
     def prepare_destinations(self, files, activities):
         """
@@ -771,7 +857,7 @@ class StageOutClient(StagingClient):
         surl = protocol.get('endpoint', '') + os.path.join(protocol.get('path', ''), self.get_path(fspec.scope, fspec.lfn))
         return {'surl': surl}
 
-    def transfer_files(self, copytool, files, activity, **kwargs):  # noqa: C901
+    def transfer_files(self, copytool, files, activity, **kwargs):
         """
             Automatically stage out files using the selected copy tool module.
 
@@ -791,7 +877,7 @@ class StageOutClient(StagingClient):
             if not os.path.isfile(pfn) or not os.access(pfn, os.R_OK):
                 msg = "Error: output pfn file does not exist: %s" % pfn
                 self.logger.error(msg)
-                self.trace_report.update(clientState='NO_REPLICA', stateReason=msg)
+                self.trace_report.update(clientState='MISSINGOUTPUTFILE', stateReason=msg)
                 self.trace_report.send()
                 raise PilotException(msg, code=ErrorCodes.MISSINGOUTPUTFILE, state="FILE_INFO_FAIL")
             if not fspec.filesize:
@@ -809,38 +895,7 @@ class StageOutClient(StagingClient):
 
         # prepare files (resolve protocol/transfer url)
         if getattr(copytool, 'require_protocols', True) and files:
-
-            ddmconf = self.infosys.resolve_storage_data()
-            allowed_schemas = getattr(copytool, 'allowed_schemas', None)
-
-            if self.infosys and self.infosys.queuedata:
-                copytool_name = copytool.__name__.rsplit('.', 1)[-1]
-                allowed_schemas = self.infosys.queuedata.resolve_allowed_schemas(activity, copytool_name) or allowed_schemas
-
-            files = self.resolve_protocols(files, activity)
-
-            for fspec in files:
-
-                protocols = self.resolve_protocol(fspec, allowed_schemas)
-                if not protocols:  #  no protocols found
-                    error = 'Failed to resolve protocol for file=%s, allowed_schemas=%s, fspec=%s' % (fspec.lfn, allowed_schemas, fspec)
-                    self.logger.error("resolve_protocol: %s" % error)
-                    raise PilotException(error, code=ErrorCodes.NOSTORAGEPROTOCOL)
-
-                # take first available protocol for copytool: FIX ME LATER if need (do iterate over all allowed protocols?)
-                protocol = protocols[0]
-
-                self.logger.info("resolved protocol to be used for transfer: data=%s" % protocol)
-
-                resolve_surl = getattr(copytool, 'resolve_surl', None)
-                if not callable(resolve_surl):
-                    resolve_surl = self.resolve_surl
-
-                r = resolve_surl(fspec, protocol, ddmconf, activity=activity)  ## pass ddmconf & activity for possible custom look up at the level of copytool
-                if r.get('surl'):
-                    fspec.turl = r['surl']
-                if r.get('ddmendpoint'):
-                    fspec.ddmendpoint = r['ddmendpoint']
+            self.require_protocols(files, copytool, activity)
 
         if not copytool.is_valid_for_copy_out(files):
             self.logger.warning('Input is not valid for transfers using copytool=%s' % copytool)

--- a/pilot/api/es_data.py
+++ b/pilot/api/es_data.py
@@ -6,6 +6,7 @@
 #
 # Authors:
 # - Wen Guan, wen.guan@cern,ch, 2018
+# - Alexey Anisenkov, anisyonk@cern.ch, 2019
 
 import traceback
 import logging
@@ -17,6 +18,7 @@ from pilot.api.data import StagingClient, StageInClient, StageOutClient
 logger = logging.getLogger(__name__)
 
 
+## THIS CLASS CAN BE DEPREATED AND REMOVED (anisyonk)
 class StagingESClient(StagingClient):
     """
         Base ES Staging Client
@@ -125,7 +127,8 @@ class StagingESClient(StagingClient):
         return result
 
 
-class StageInESClient(StagingESClient, StageInClient):
+## THIS CLASS CAN BE DEPREATED AND REMOVED (anisyonk)
+class StageInESClientDeprecateME(StagingESClient, StageInClient):
 
     def process_storage_id(self, files):
         """
@@ -157,7 +160,8 @@ class StageInESClient(StagingESClient, StageInClient):
         return super(StageInESClient, self).transfer_files(copytool, files, activity=activity, ddmendpoint=ddmendpoint, **kwargs)
 
 
-class StageOutESClient(StagingESClient, StageOutClient):
+## THIS CLASS CAN BE DEPREATED AND REMOVED (anisyonk)
+class StageOutESClientDeprecateME(StagingESClient, StageOutClient):
 
     def transfer_files(self, copytool, files, activity, ddmendpoint, **kwargs):
         """
@@ -179,3 +183,45 @@ class StageOutESClient(StagingESClient, StageOutClient):
                 fspec.ddmendpoint = ddmendpoint
 
         return super(StageOutESClient, self).transfer_files(copytool, files, activity, **kwargs)
+
+
+class StageInESClient(StageInClient):
+
+    def __init__(self, *argc, **kwargs):
+        super(StagingClient, self).__init__(*argc, **kwargs)
+
+        self.copytool_modules.setdefault('objectstore', {'module_name': 'objectstore'})
+        self.acopytools.setdefault('es_events_read', ['objectstore'])
+
+    def prepare_sources(self, files, activities=None):
+        """
+            Customize/prepare source data for each entry in `files` optionally checking data for requested `activities`
+            (custom StageClient could extend this logic if need)
+            :param files: list of `FileSpec` objects to be processed
+            :param activities: string or ordered list of activities to resolve `astorages` (optional)
+            :return: None
+
+            If storage_id is specified, replace ddmendpoint by parsing storage_id
+        """
+
+        if not self.infosys:
+            self.logger.warning('infosys instance is not initialized: skip calling prepare_sources()')
+            return
+
+        for fspec in files:
+            if fspec.storage_token:   ## FIX ME LATER: no need to parse each time storage_id, all this staff should be applied in FileSpec clean method
+                storage_id, path_convention = fspec.get_storage_id_and_path_convention()
+                if path_convention and path_convention == 1000:
+                    fspec.scope = 'transient'
+                if storage_id:
+                    fspec.ddmendpoint = self.infosys.get_ddmendpoint(storage_id)
+                logger.info("Processed file with storage id: %s" % fspec)
+
+
+class StageOutESClient(StageOutClient):
+
+    def __init__(self, *argc, **kwargs):
+        super(StageOutESClient, self).__init__(*argc, **kwargs)
+
+        self.copytool_modules.setdefault('objectstore', {'module_name': 'objectstore'})
+        self.acopytools.setdefault('es_events', ['objectstore'])

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -157,7 +157,7 @@ def _stage_in(args, job):
             client = StageInClient(job.infosys, logger=log, trace_report=trace_report)
             activity = 'pr'
         kwargs = dict(workdir=job.workdir, cwd=job.workdir, usecontainer=False, job=job)  #, mode='stage-in')
-
+        client.prepare_sources(job.indata)
         client.transfer(job.indata, activity=activity, **kwargs)
     except PilotException as error:
         log.error('PilotException caught: %s' % error)

--- a/pilot/eventservice/workexecutor/plugins/genericexecutor.py
+++ b/pilot/eventservice/workexecutor/plugins/genericexecutor.py
@@ -177,8 +177,10 @@ class GenericExecutor(BaseExecutor):
             file_spec = FileSpec(filetype='output', **file_data)
             xdata = [file_spec]
             client = StageOutESClient(job.infosys, logger=log)
+            activity = ['es_events', 'pw']  ## FIX ME LATER: replace `pw` with `write_lan` once AGIS is updated (acopytools)
             kwargs = dict(workdir=job.workdir, cwd=job.workdir, usecontainer=False, job=job)
-            client.transfer(xdata, activity=['es_events', 'pw'], **kwargs)
+            client.prepare_destinations(xdata, activity)  ## IF ES job should be allowed to write only at `es_events` astorages, then fix activity names here
+            client.transfer(xdata, activity=activity, **kwargs)
         except exception.PilotException, error:
             log.error(error.get_detail())
         except Exception, e:

--- a/pilot/info/filespec.py
+++ b/pilot/info/filespec.py
@@ -65,12 +65,13 @@ class FileSpec(BaseData):
     workdir = None     # used to declare file-specific work dir (location of given local file when it's used for transfer by copytool)
     protocol_id = None  # id of the protocol to be used to construct turl
     is_tar = False     # whether it's a tar file or not
+    ddm_activity = None  # DDM activity names (e.g. [read_lan, read_wan]) which should be used to resolve appropriate protocols from StorageData.arprotocols
 
     # specify the type of attributes for proper data validation and casting
     _keys = {int: ['filesize', 'mtime', 'status_code'],
              str: ['lfn', 'guid', 'checksum', 'scope', 'dataset', 'ddmendpoint',
                    'filetype', 'surl', 'turl', 'status', 'workdir', 'accessmode', 'allowremoteinputs', 'storage_token'],
-             list: ['replicas', 'inputddms'],
+             list: ['replicas', 'inputddms', 'ddm_activity'],
              bool: []
              }
 

--- a/pilot/info/queuedata.py
+++ b/pilot/info/queuedata.py
@@ -129,7 +129,7 @@ class QueueData(BaseData):
     def resolve_allowed_schemas(self, activity, copytool=None):
         """
             Resolve list of allowed schemas for given activity and requested copytool based on `acopytools_schemas` settings
-            :param activity: ordered list of activity names to look up data
+            :param activity: str or ordered list of transfer activity names to resolve acopytools related data
             :return: list of protocol schemes
         """
 

--- a/pilot/info/storageactivitymaps.py
+++ b/pilot/info/storageactivitymaps.py
@@ -6,6 +6,7 @@
 # Authors:
 # - Wen Guan, wen.guan@cern.ch, 2018
 
+## THIS FILE IS DEPRECATED AND CAN BE REMOVED LATER (anisyonk)
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pilot/test/test_esstager.py
+++ b/pilot/test/test_esstager.py
@@ -73,7 +73,8 @@ class TestStager(unittest.TestCase):
             workdir = os.path.dirname(output_file)
             client = StageOutESClient(infoservice)
             kwargs = dict(workdir=workdir, cwd=workdir, usecontainer=False)
-            client.transfer(xdata, activity=['es_events'], **kwargs)
+            client.prepare_destinations(xdata, activity='es_events')
+            client.transfer(xdata, activity='es_events', **kwargs)
         except exception.PilotException, error:
             logger.error("Pilot Exeception: %s, %s" % (error.get_detail(), traceback.format_exc()))
         except Exception, e:
@@ -115,6 +116,7 @@ class TestStager(unittest.TestCase):
             workdir = os.path.dirname(output_file)
             client = StageOutESClient(infoservice)
             kwargs = dict(workdir=workdir, cwd=workdir, usecontainer=False)
+            client.prepare_destinations(xdata, activity=['es_events', 'pw'])  # allow to write to `es_events` and `pw` astorages
             client.transfer(xdata, activity=['es_events', 'pw'], **kwargs)
         except exception.PilotException, error:
             logger.error("Pilot Exeception: %s, %s" % (error.get_detail(), traceback.format_exc()))
@@ -157,6 +159,7 @@ class TestStager(unittest.TestCase):
             workdir = os.path.dirname(output_file)
             client = StageOutESClient(infoservice)
             kwargs = dict(workdir=workdir, cwd=workdir, usecontainer=False)
+            client.prepare_destinations(xdata, activity=['es_events_non_exist', 'pw'])  # allow to write to `es_events_non_exist` and `pw` astorages
             client.transfer(xdata, activity=['es_events_non_exist', 'pw'], **kwargs)
         except exception.PilotException, error:
             logger.error("Pilot Exeception: %s, %s" % (error.get_detail(), traceback.format_exc()))
@@ -199,6 +202,7 @@ class TestStager(unittest.TestCase):
             workdir = os.path.dirname(output_file)
             client = StageOutESClient(infoservice)
             kwargs = dict(workdir=workdir, cwd=workdir, usecontainer=False)
+            client.prepare_destinations(xdata, activity=['es_events', 'pw'])  # allow to write to `es_events` and `pw` astorages
             client.transfer(xdata, activity=['es_events', 'pw'], **kwargs)
         except exception.PilotException, error:
             logger.error("Pilot Exeception: %s, %s" % (error.get_detail(), traceback.format_exc()))
@@ -227,6 +231,7 @@ class TestStager(unittest.TestCase):
             workdir = os.path.dirname(output_file)
             client = StageInESClient(infoservice)
             kwargs = dict(workdir=workdir, cwd=workdir, usecontainer=False)
+            client.prepare_sources(xdata)
             client.transfer(xdata, activity=['es_events_read'], **kwargs)
         except exception.PilotException, error:
             logger.error("Pilot Exeception: %s, %s" % (error.get_detail(), traceback.format_exc()))
@@ -269,6 +274,7 @@ class TestStager(unittest.TestCase):
             workdir = os.path.dirname(output_file)
             client = StageOutESClient(infoservice)
             kwargs = dict(workdir=workdir, cwd=workdir, usecontainer=False)
+            client.prepare_destinations(xdata, activity=['es_events_no_exist', 'pw'])  # allow to write to `es_events_no_exist` and `pw` astorages
             client.transfer(xdata, activity=['es_events_no_exist', 'pw'], **kwargs)
         except exception.PilotException, error:
             logger.error("Pilot Exeception: %s, %s" % (error.get_detail(), traceback.format_exc()))
@@ -297,6 +303,7 @@ class TestStager(unittest.TestCase):
             workdir = os.path.dirname(output_file)
             client = StageInESClient(infoservice)
             kwargs = dict(workdir=workdir, cwd=workdir, usecontainer=False)
+            client.prepare_sources(xdata)
             client.transfer(xdata, activity=['es_events_read'], **kwargs)
         except exception.PilotException, error:
             logger.error("Pilot Exeception: %s, %s" % (error.get_detail(), traceback.format_exc()))

--- a/pilot/test/test_esworkexecutor.py
+++ b/pilot/test/test_esworkexecutor.py
@@ -90,6 +90,7 @@ class TestESWorkExecutorGrid(unittest.TestCase):
             # download input files
             client = StageInESClient(job.infosys, logger=logger)
             kwargs = dict(workdir=job.workdir, cwd=job.workdir, usecontainer=False, job=job)
+            client.prepare_sources(job.indata)
             client.transfer(job.indata, activity='pr', **kwargs)
 
             # get the payload command from the user specific code


### PR DESCRIPTION
**Functional updates**:

 -  refactored and unified ES StagingClients
 -  automatically prefer `LAN` protocol (read_lan/write_lan) for stage-in/stage-out file if source/destination RSE is local for given PQ (defined in `inputddms=astorages['read_lan']`)

 **Updates**:
 - base movers workflow upgraded
 - introduce `require_input_protocols` mode to look up and manually form input replicas for specific copytool (activated for the objectstore mover, ES workflow)
 - refactor and simplify `objecstore` copytool

To BE TESTED

Wen, as I see `pilot2` currently does not support `es_failover` transfers. It's better to implement failover transfers at the top level (for any jobs), however since it's not covered yet even for ES I postponed this.

Wen, should we allow ES jobs to write data into `astorages['write_lan']` or only to `astorages['es_events']`?
currently  I set resolution order for destination RSE is ['es_events', 'write_lan'] activities of `astorages`
