### PR TITLE
remove sleep 10

### DIFF
--- a/pilot/control/job.py
+++ b/pilot/control/job.py
@@ -868,8 +868,6 @@ def proceed_with_getjob(timefloor, starttime, jobnumber, getjob_requests, harves
     :return: Boolean.
     """
 
-    time.sleep(10)
-
     # use for testing thread exceptions. the exception will be picked up by ExcThread run() and caught in job.control()
     # raise NoLocalSpace('testing exception from proceed_with_getjob')
 


### PR DESCRIPTION
I'm not sure the reasons for having this sleep for 10 s before getting a job, but it seems unnecessary especially in push mode where the job description file is already present. I didn't notice any bad effects from testing jobs without the sleep.