### PR TITLE
Copytools failover fix

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -666,8 +666,7 @@ class StageInClient(StagingClient):
 
             for fspec in files:
                 resolve_replica = getattr(copytool, 'resolve_replica', None)
-                if not callable(resolve_replica):
-                    resolve_replica = self.resolve_replica
+                resolve_replica = self.resolve_replica if not callable(resolve_replica) else resolve_replica
 
                 ## prepare schemas which will be used to look up first the replicas allowed for direct access mode
                 primary_schemas = self.direct_localinput_allowed_schemas if fspec.accessmode == 'direct' else None

--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -546,7 +546,7 @@ class StageInClient(StagingClient):
         """
 
         if not fspec.replicas:
-            self.logger.warning('resolve_replicas() recevied no fspec.replicas')
+            self.logger.warning('resolve_replicas() received no fspec.replicas')
             return
 
         allowed_schemas = allowed_schemas or [None]
@@ -654,8 +654,10 @@ class StageInClient(StagingClient):
         if allow_direct_access:
             self.set_accessmodes_for_direct_access(files, direct_access_type)
 
-        if getattr(copytool, 'require_replicas', False) and files and files[0].replicas is None:
-            files = self.resolve_replicas(files)
+        if getattr(copytool, 'require_replicas', False) and files:
+            if files[0].replicas is None:  ## look up replicas only once
+                files = self.resolve_replicas(files)
+
             allowed_schemas = getattr(copytool, 'allowed_schemas', None)
 
             if self.infosys and self.infosys.queuedata:

--- a/pilot/copytool/gfal.py
+++ b/pilot/copytool/gfal.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 require_replicas = True  ## indicate if given copytool requires input replicas to be resolved
 
-allowed_schemas = ['srm', 'gsiftp', 'https', 'davs']  # prioritized list of supported schemas for transfers by given copytool
+allowed_schemas = ['srm', 'gsiftp', 'https', 'davs', 'root']  # prioritized list of supported schemas for transfers by given copytool
 
 
 def is_valid_for_copy_in(files):

--- a/pilot/info/jobinfo.py
+++ b/pilot/info/jobinfo.py
@@ -83,6 +83,7 @@ class JobInfoProvider(object):
         master_data = self.job.overwrite_storagedata or {}
         data.update((k, v) for k, v in master_data.iteritems() if k in set(ddmendpoints or master_data) & set(master_data))
 
-        logger.info('storagedata: following data extracted from Job definition will be used: %s' % data)
+        if data:
+            logger.info('storagedata: following data extracted from Job definition will be used: %s' % data)
 
         return data


### PR DESCRIPTION
 - fix copytools failover logic for stage-in (enforce replica look up for copytool allowed schemas)
 - add `root://` protocol into supported list for the `gfalcopy` sitemover