### PR TITLE
Better error reporting for rucio mover errors

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -358,7 +358,7 @@ class StagingClient(object):
             except PilotException as e:
                 msg = 'failed to execute transfer_files(): PilotException caught: %s' % e
                 self.logger.warning(msg)
-                caught_errors.append(e)
+                caught_errors.append(e.get_last_error())
             except TimeoutException as e:
                 msg = 'function timed out: %s' % e
                 self.logger.warning(msg)
@@ -392,7 +392,7 @@ class StagingClient(object):
                 code = ErrorCodes.STAGEINFAILED
             self.logger.fatal('caught_errors=%s' % str(caught_errors))
             self.logger.fatal('code=%s' % str(code))
-            raise PilotException('failed to transfer files using copytools=%s, error=%s' % (copytools, caught_errors), code=code)
+            raise PilotException('failed to transfer files using copytools=%s' % (copytools), ','.join(caught_errors), code=code)
 
         self.logger.debug('result=%s' % str(result))
         return result

--- a/pilot/common/errorcodes.py
+++ b/pilot/common/errorcodes.py
@@ -402,16 +402,17 @@ class ErrorCodes:
         :return: formatted error diagnostics (string).
         """
 
+        max_message_length = 256
         try:
             standard_message = self._error_messages[code] + ":"
         except Exception:
             standard_message = ""
         try:
             if diag:
-                if len(diag) >= len(standard_message):
-                    error_message = standard_message + diag[-(len(diag) - len(standard_message)):]
+                if len(diag) + len(standard_message) > max_message_length:
+                    error_message = standard_message + diag[-(max_message_length - len(standard_message)):]
                 else:
-                    error_message = standard_message + diag[-(len(standard_message) - len(diag)):]
+                    error_message = standard_message + diag
             else:
                 error_message = standard_message
         except Exception:

--- a/pilot/common/exception.py
+++ b/pilot/common/exception.py
@@ -69,6 +69,11 @@ class PilotException(Exception):
     def get_error_code(self):
         return self._errorCode
 
+    def get_last_error(self):
+        if self.args:
+            return self.args[-1]
+        return self._message
+
 
 class NotImplemented(PilotException):
     """

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -165,7 +165,7 @@ def _stage_in(args, job):
         import traceback
         error_msg = traceback.format_exc()
         log.error(error_msg)
-        msg = errors.format_diagnostics(error.get_error_code(), error_msg)
+        msg = errors.format_diagnostics(error.get_error_code(), error.get_last_error())
         job.piloterrorcodes, job.piloterrordiags = errors.add_error_code(error.get_error_code(), msg=msg)
     except Exception as error:
         log.error('failed to stage-in: error=%s' % error)
@@ -659,7 +659,7 @@ def _do_stageout(job, xdata, activity, title):
         import traceback
         error_msg = traceback.format_exc()
         log.error(error_msg)
-        msg = errors.format_diagnostics(error.get_error_code(), error_msg)
+        msg = errors.format_diagnostics(error.get_error_code(), error.get_last_error())
         job.piloterrorcodes, job.piloterrordiags = errors.add_error_code(error.get_error_code(), msg=msg)
     except Exception:
         import traceback

--- a/pilot/copytool/rucio.py
+++ b/pilot/copytool/rucio.py
@@ -36,6 +36,7 @@ def is_valid_for_copy_in(files):
 def is_valid_for_copy_out(files):
     return True  ## FIX ME LATER
 
+
 def verify_stage_out(fspec):
     """
     Checks that the uploaded file is physically at the destination.
@@ -46,6 +47,7 @@ def verify_stage_out(fspec):
     uploaded_file = {'name': fspec.lfn, 'scope': fspec.scope}
     logger.info('Checking file: %s' % str(fspec.lfn))
     return rsemgr.exists(rse_settings, [uploaded_file])
+
 
 # @timeout(seconds=600)
 def copy_in(files, **kwargs):

--- a/pilot/copytool/rucio.py
+++ b/pilot/copytool/rucio.py
@@ -106,7 +106,8 @@ def copy_in(files, **kwargs):
                                 stateReason=error_msg, timeEnd=time())
             if not ignore_errors:
                 trace_report.send()
-                raise PilotException(error_msg, code=error.get('rcode'), state='FAILED')
+                msg = ' %s:%s, %s' % (fspec.scope, fspec.lfn, str(error_msg).replace('\n', ' '))
+                raise PilotException(msg, code=error.get('rcode'), state='FAILED')
 
         # verify checksum; compare local checksum with catalog value (fspec.checksum), use same checksum type
         destination = os.path.join(dst, fspec.lfn)
@@ -181,7 +182,8 @@ def copy_out(files, **kwargs):
                                 timeEnd=time())
             if not ignore_errors:
                 trace_report.send()
-                raise PilotException(error.get('error'), code=error.get('rcode'), state=error.get('state'))
+                msg = ' %s:%s, %s' % (fspec.scope, fspec.lfn, str(error_msg).replace('\n', ' '))
+                raise PilotException(msg, code=error.get('rcode'), state=error.get('state'))
 
         if summary:  # resolve final pfn (turl) from the summary JSON
             if not os.path.exists(summary_file_path):
@@ -211,7 +213,7 @@ def copy_out(files, **kwargs):
                             logger.info('local checksum (%s) = remote checksum (%s)' % (local_checksum, adler32))
                         else:
                             logger.warning('checksum could not be verified: local checksum (%s), remote checksum (%s)' %
-                                           str(local_checksum), str(adler32))
+                                           (str(local_checksum), str(adler32)))
         if not fspec.status_code:
             fspec.status_code = 0
             fspec.status = 'transferred'
@@ -258,11 +260,13 @@ def _stage_in_api(dst, fspec, trace_report):
     else:
         result = download_client.download_dids([f], trace_custom_fields=trace_pattern)
 
-    client_state = 'FAILED'
-    if result:
-        client_state = result[0].get('clientState', 'FAILED')
+    logger.debug('Rucio download client returned %s' % result)
+    if not result:
+        raise Exception('Unknown error')
+    if result[0].get('clientState', 'FAILED') == 'FAILED':
+        raise Exception(result[0].get('clientError', 'Unknown error'))
 
-    return client_state
+    return 'DONE'
 
 
 def _stage_out_api(fspec, summary_file_path, trace_report):
@@ -302,19 +306,23 @@ def _stage_out_api(fspec, summary_file_path, trace_report):
         result = upload_client.upload([f], summary_file_path)
     except UnboundLocalError:
         logger.warning('rucio still needs a bug fix of the summary in the uploadclient')
-        result = 0
 
-    client_state = 'FAILED'
-    if result == 0:
-        try:
-            file_exists = verify_stage_out(fspec)
-            logger.info('File exists at the storage: %s' % str(file_exists))
-            if not file_exists:
-                raise PilotException('stageOut: Physical check after upload failed.')
-        except Exception as e:
-            msg = 'stageOut: File existence verification failed with: %s' % str(e)
-            logger.info(msg)
-            raise PilotException(msg)
-        client_state = 'DONE'
+    # Old upload client returns 0, new one returns list of file dicts
+    if type(result) == list:
+        logger.debug('Rucio upload client returned %s' % result)
+        if not result:
+            raise Exception('Unknown error')
+        if not result[0].get('upload_result', {}).get('success', False):
+            raise Exception(result[0].get('upload_error', 'Unknown error'))
 
-    return client_state
+    try:
+        file_exists = verify_stage_out(fspec)
+        logger.info('File exists at the storage: %s' % str(file_exists))
+        if not file_exists:
+            raise PilotException('stageOut: Physical check after upload failed.')
+    except Exception as e:
+        msg = 'stageOut: File existence verification failed with: %s' % str(e)
+        logger.info(msg)
+        raise PilotException(msg)
+
+    return 'DONE'


### PR DESCRIPTION
Instead of a traceback, this now reports the real error returned from rucio download or upload. However, the current version of rucio does not propagate errors well so the message will always be "None of the requested files have been downloaded". I'm working on fixing this so a future version of Rucio will report the real error.