### PR TITLE
get traces info back from rucio for better error message

### DIFF
--- a/pilot/copytool/rucio.py
+++ b/pilot/copytool/rucio.py
@@ -267,13 +267,9 @@ def _stage_in_api(dst, fspec, trace_report, trace_report_out):
 
     # download client raises an exception if any file failed
     if fspec.turl:
-        # restore the following line when it is supported on the rucio client
-        #result = download_client.download_pfns([f], 1, trace_custom_fields=trace_pattern, traces_copy_out=trace_report_out)
-        result = download_client.download_pfns([f], 1, trace_custom_fields=trace_pattern)
+        result = download_client.download_pfns([f], 1, trace_custom_fields=trace_pattern, traces_copy_out=trace_report_out)
     else:
-        # restore the following line when it is supported on the rucio client
-        #result = download_client.download_dids([f], trace_custom_fields=trace_pattern, traces_copy_out=trace_report_out)
-        result = download_client.download_dids([f], trace_custom_fields=trace_pattern)
+        result = download_client.download_dids([f], trace_custom_fields=trace_pattern, traces_copy_out=trace_report_out)
 
     logger.debug('Rucio download client returned %s' % result)
 
@@ -314,8 +310,7 @@ def _stage_out_api(fspec, summary_file_path, trace_report, trace_report_out):
 
     # upload client raises an exception if any file failed
     try:
-        # TODO: Add traces_copy_out=trace_report_out when supported in rucio
-        result = upload_client.upload([f], summary_file_path=summary_file_path)
+        result = upload_client.upload([f], summary_file_path=summary_file_path, traces_copy_out=trace_report_out)
     except UnboundLocalError:
         logger.warning('rucio still needs a bug fix of the summary in the uploadclient')
 


### PR DESCRIPTION
IMPORTANT! Do not merge until the rucio version used by the pilot is 1.20.7 or later, since the arguments added here are not available until that version.

1.20.7 has been in testing for a week and tomorrow I'll discuss with the DDM people whether we can set it as default.