### PR TITLE
Stage out update for analy prod unification 

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -978,6 +978,12 @@ class StageOutClient(StagingClient):
         # check if files exist before actual processing
         # populate filesize if need, calc checksum
         for fspec in files:
+
+            if not fspec.ddmendpoint:  # ensure that output destination is properly set
+                msg = 'No output RSE defined for file=%s' % fspec.lfn
+                self.logger.error(msg)
+                raise PilotException(msg, code=ErrorCodes.NOSTORAGE, state='NO_OUTPUTSTORAGE_DEFINED')
+
             pfn = fspec.surl or getattr(fspec, 'pfn', None) or os.path.join(kwargs.get('workdir', ''), fspec.lfn)
             if not os.path.isfile(pfn) or not os.access(pfn, os.R_OK):
                 msg = "Error: output pfn file does not exist: %s" % pfn

--- a/pilot/control/data.py
+++ b/pilot/control/data.py
@@ -650,7 +650,8 @@ def _do_stageout(job, xdata, activity, title):
     try:
         client = StageOutClient(job.infosys, logger=log, trace_report=trace_report)
         kwargs = dict(workdir=job.workdir, cwd=job.workdir, usecontainer=False, job=job)  #, mode='stage-out')
-        client.prepare_destinations(xdata, activity)  ## FIX ME LATER: split activities: for astorages and for copytools (to unify with ES workflow)
+        # prod analy unification: use destination preferences from PanDA server
+        #client.prepare_destinations(xdata, activity)  ## FIX ME LATER: split activities: for astorages and for copytools (to unify with ES workflow)
         client.transfer(xdata, activity, **kwargs)
     except PilotException as error:
         import traceback


### PR DESCRIPTION
- use PanDA preference for stage-out destination (data+log files)
- fail job if PanDA does not explicitly say where to store output (if ddmEndPointOut is not filled for whatever reasons, no smart defaults by Pilot anymore) 

