### PR TITLE
Resolve timeout issues

### DIFF
--- a/pilot/copytool/rucio.py
+++ b/pilot/copytool/rucio.py
@@ -61,7 +61,6 @@ def copy_in(files, **kwargs):
         :raise: PilotException in case of controlled error
     """
 
-    #allow_direct_access = kwargs.get('allow_direct_access')
     ignore_errors = kwargs.get('ignore_errors')
     trace_report = kwargs.get('trace_report')
 
@@ -76,14 +75,6 @@ def copy_in(files, **kwargs):
         trace_report.update(localSite=localsite, remoteSite=fspec.ddmendpoint, filesize=fspec.filesize)
         trace_report.update(filename=fspec.lfn, guid=fspec.guid.replace('-', ''))
         trace_report.update(scope=fspec.scope, dataset=fspec.dataset)
-
-        # continue loop for files that are to be accessed directly
-        #if fspec.is_directaccess(ensure_replica=False) and allow_direct_access and fspec.accessmode == 'direct':
-        #    fspec.status_code = 0
-        #    fspec.status = 'remote_io'
-        #    trace_report.update(url=fspec.turl, clientState='FOUND_ROOT', stateReason='direct_access')
-        #    trace_report.send()
-        #    continue
 
         trace_report.update(catStart=time())  ## is this metric still needed? LFC catalog
         fspec.status_code = 0
@@ -250,10 +241,13 @@ def copy_out(files, **kwargs):
 
         logger.info('the file will be uploaded to %s' % str(fspec.ddmendpoint))
         trace_report_out = []
+        transfer_timeout = get_timeout(fspec.filesize)
+        ctimeout = transfer_timeout + 10  # give the API a chance to do the time-out first
+        logger.info('overall transfer timeout=%s' % ctimeout)
+
         try:
-            #transfer_timeout = get_timeout(fspec.filesize, add=10)  # give the API a chance to do the time-out first
-            #timeout(transfer_timeout)(_stage_out_api)(fspec, summary_file_path, trace_report, trace_report_out)
-            _stage_out_api(fspec, summary_file_path, trace_report, trace_report_out)
+            timeout(ctimeout)(_stage_out_api)(fspec, summary_file_path, trace_report, trace_report_out, transfer_timeout)
+            #_stage_out_api(fspec, summary_file_path, trace_report, trace_report_out)
         except Exception as error:
             error_msg = str(error)
             # Try to get a better error message from the traces
@@ -414,7 +408,7 @@ def _stage_in_api_bulk(dst, files, trace_reports, trace_report_out):
     logger.debug('Rucio download client returned %s' % result)
 
 
-def _stage_out_api(fspec, summary_file_path, trace_report, trace_report_out):
+def _stage_out_api(fspec, summary_file_path, trace_report, trace_report_out, transfer_timeout):
 
     # init. download client
     from rucio.client.uploadclient import UploadClient
@@ -433,8 +427,8 @@ def _stage_out_api(fspec, summary_file_path, trace_report, trace_report_out):
     f['did_scope'] = fspec.scope
     f['no_register'] = True
 
-    if fspec.filesize:
-        f['transfer_timeout'] = get_timeout(fspec.filesize)
+    if transfer_timeout:
+        f['transfer_timeout'] = transfer_timeout
 
     # if fspec.storageId and int(fspec.storageId) > 0:
     #     if fspec.turl and fspec.is_nondeterministic:

--- a/pilot/copytool/rucio.py
+++ b/pilot/copytool/rucio.py
@@ -20,7 +20,7 @@ from time import time
 
 from .common import resolve_common_transfer_errors, verify_catalog_checksum, get_timeout
 from pilot.common.exception import PilotException, StageOutFailure, ErrorCodes
-#from pilot.util.timer import timeout
+from pilot.util.timer import timeout
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -92,9 +92,9 @@ def copy_in(files, **kwargs):
 
         trace_report_out = []
         try:
-            #transfer_timeout = get_timeout(fspec.filesize, add=10)  # give the API a chance to do the time-out first
-            #timeout(transfer_timeout)(_stage_in_api)(dst, fspec, trace_report, trace_report_out)
-            _stage_in_api(dst, fspec, trace_report, trace_report_out)
+            transfer_timeout = get_timeout(fspec.filesize, add=10)  # give the API a chance to do the time-out first
+            timeout(transfer_timeout)(_stage_in_api)(dst, fspec, trace_report, trace_report_out)
+            #_stage_in_api(dst, fspec, trace_report, trace_report_out)
         except Exception as error:
             error_msg = str(error)
             # Try to get a better error message from the traces

--- a/pilot/util/timer.py
+++ b/pilot/util/timer.py
@@ -141,12 +141,15 @@ class TimedProcess(object):
             ret = queue.get(block=True, timeout=timeout)
         except Empty:
             self.is_timeout = True
+            process.terminate()
             raise TimeoutException("Timeout reached", timeout=timeout)
         finally:
             while process.is_alive():
-                process.terminate()
                 process.join(1)
-                if process.is_alive() and process.pid:
+                if process.is_alive():  ## still alive, force terminate
+                    process.terminate()
+                    process.join(1)
+                if process.is_alive() and process.pid:  ## still alive, hard kill
                     os.kill(process.pid, signal.SIGKILL)
 
             multiprocessing.active_children()

--- a/pilot/workflow/generic.py
+++ b/pilot/workflow/generic.py
@@ -74,7 +74,7 @@ def interrupt(args, signum, frame):
 
     add_to_pilot_timing('0', PILOT_KILL_SIGNAL, time(), args)
     add_to_pilot_timing('1', PILOT_KILL_SIGNAL, time(), args)
-    logger.warning('caught signal: %s in FRAME=\n' % (sig, '\n'.join(traceback.format_stack(frame))))
+    logger.warning('caught signal: %s in FRAME=\n%s' % (sig, '\n'.join(traceback.format_stack(frame))))
 
     args.signal = sig
     logger.warning('will instruct threads to abort and update the server')

--- a/pilot/workflow/generic.py
+++ b/pilot/workflow/generic.py
@@ -14,6 +14,8 @@ from __future__ import print_function  # Python 2, 2to3 complains about this
 import functools
 import signal
 import threading
+import traceback
+
 from time import time, sleep
 from sys import stderr
 from os import getpid
@@ -72,7 +74,8 @@ def interrupt(args, signum, frame):
 
     add_to_pilot_timing('0', PILOT_KILL_SIGNAL, time(), args)
     add_to_pilot_timing('1', PILOT_KILL_SIGNAL, time(), args)
-    logger.warning('caught signal: %s' % sig)
+    logger.warning('caught signal: %s in FRAME=\n' % (sig, '\n'.join(traceback.format_stack(frame))))
+
     args.signal = sig
     logger.warning('will instruct threads to abort and update the server')
     args.abort_job.set()


### PR DESCRIPTION
- fix `timer.TimedProcess` logic
- enable timeout protection for transfers using rucio copytool  (`copy_in` & `copy_in` methods)