### PR TITLE
add endTime to final heartbeat

### DIFF
--- a/pilot/control/job.py
+++ b/pilot/control/job.py
@@ -592,6 +592,7 @@ def add_timing_and_extracts(data, job, state, args):
         if extracts != "":
             logger.warning('\nXXXXXXXXXXXXXXXXXXXXX[begin log extracts]\n%s\nXXXXXXXXXXXXXXXXXXXXX[end log extracts]' % extracts)
     data['pilotLog'] = extracts[:1024]
+    data['endTime'] = time.time()
 
 
 def add_memory_info(data, workdir, name=""):


### PR DESCRIPTION
I'm trying to make aCT walltime reporting more accurate, so would prefer to use timings reported by the pilot rather than by ARC. This change adds endTime to the final heartbeat so that aCT can report it to panda.