### PR TITLE
Use Thread-based timeout implementation for rucio copytool 

### DIFF
--- a/pilot/copytool/rucio.py
+++ b/pilot/copytool/rucio.py
@@ -332,7 +332,7 @@ def copy_out(files, **kwargs):  # noqa: C901
         error_msg = ""
         ec = 0
         try:
-            ec, trace_report_out = timeout(ctimeout, timer=TimedThread)(_stage_out_api)(fspec, summary_file_path, trace_report, trace_report_out, transfer_timeout)
+            ec, trace_report_out = timeout(ctimeout, TimedThread)(_stage_out_api)(fspec, summary_file_path, trace_report, trace_report_out, transfer_timeout)
             #_stage_out_api(fspec, summary_file_path, trace_report, trace_report_out)
         except PilotException as error:
             error_msg = str(error)

--- a/pilot/copytool/rucio.py
+++ b/pilot/copytool/rucio.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 
 from .common import resolve_common_transfer_errors, verify_catalog_checksum, get_timeout
 from pilot.common.exception import PilotException, StageOutFailure, ErrorCodes
-from pilot.util.timer import timeout
+from pilot.util.timer import timeout, TimedThread
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -94,7 +94,7 @@ def copy_in(files, **kwargs):
         error_msg = ""
         ec = 0
         try:
-            ec, trace_report_out = timeout(ctimeout)(_stage_in_api)(dst, fspec, trace_report, trace_report_out, transfer_timeout, use_pcache)
+            ec, trace_report_out = timeout(ctimeout, timer=TimedThread)(_stage_in_api)(dst, fspec, trace_report, trace_report_out, transfer_timeout, use_pcache)
             #_stage_in_api(dst, fspec, trace_report, trace_report_out)
         except Exception as error:
             error_msg = str(error)
@@ -332,7 +332,7 @@ def copy_out(files, **kwargs):  # noqa: C901
         error_msg = ""
         ec = 0
         try:
-            ec, trace_report_out = timeout(ctimeout)(_stage_out_api)(fspec, summary_file_path, trace_report, trace_report_out, transfer_timeout)
+            ec, trace_report_out = timeout(ctimeout, timer=TimedThread)(_stage_out_api)(fspec, summary_file_path, trace_report, trace_report_out, transfer_timeout)
             #_stage_out_api(fspec, summary_file_path, trace_report, trace_report_out)
         except PilotException as error:
             error_msg = str(error)

--- a/pilot/util/timer.py
+++ b/pilot/util/timer.py
@@ -166,17 +166,20 @@ else:  ## Windows
     Timer = TimedThread
 
 
-def timeout(seconds):
+def timeout(seconds, timer=None):
     """
     Decorator for a function which causes it to timeout (stop execution) once passed given number of seconds.
+    :param timer: timer class (by default is Timer)
     :raise: TimeoutException in case of timeout interrupt
     """
+
+    timer = timer or Timer
 
     def decorate(function):
 
         @wraps(function)
         def wrapper(*args, **kwargs):
-            return Timer(seconds).run(function, args, kwargs)
+            return timer(seconds).run(function, args, kwargs)
 
         return wrapper
 

--- a/pilot/util/timer.py
+++ b/pilot/util/timer.py
@@ -96,9 +96,9 @@ class TimedThread(object):
             return ret[1]
         else:
             try:
-                _r = ret[1][0](ret[1][1]).with_traceback(ret[1][2])
+                _r = ret[1][0](ret[1][1]).with_traceback(ret[1][2])  # python3
             except Exception:
-                _r = ret[1][0], ret[1][1], ret[1][2]
+                exec("raise ret[1][0], ret[1][1], ret[1][2]")   # python3 compatible code for pyhon2 execution
             raise _r
 
 

--- a/pilot/util/timer.py
+++ b/pilot/util/timer.py
@@ -97,8 +97,8 @@ class TimedThread(object):
         else:
             try:
                 _r = ret[1][0](ret[1][1]).with_traceback(ret[1][2])  # python3
-            except Exception:
-                exec("raise ret[1][0], ret[1][1], ret[1][2]")   # python3 compatible code for pyhon2 execution
+            except AttributeError:
+                exec("raise ret[1][0], ret[1][1], ret[1][2]")   # python3 compatible code for python2 execution
             raise _r
 
 


### PR DESCRIPTION
- `timeout` decorator update: allow passing `Timer` class implementation. Fix python3 compatibility issue with `TimedThread` code)
- Switch from Process-based to Thread-based timer implementation for transfer operations by rucio copytool