### PR TITLE
Migration to CRIC

### DIFF
--- a/pilot/info/dataloader.py
+++ b/pilot/info/dataloader.py
@@ -190,7 +190,7 @@ class DataLoader(object):
             try:
                 data = parser(content)
             except Exception as e:
-                logger.fatal("failed to parse data from source=%s .. skipped, error=%s" % (dat.get('url'), e))
+                logger.fatal("failed to parse data from source=%s (resource=%s, cache=%s).. skipped, error=%s" % (dat.get('url'), key, dat.get('fname'), e))
                 data = None
             if data:
                 return data

--- a/pilot/info/dataloader.py
+++ b/pilot/info/dataloader.py
@@ -28,6 +28,7 @@ except Exception:
 from datetime import datetime, timedelta
 
 from pilot.util.timer import timeout
+from pilot.util.https import ctx
 
 import logging
 logger = logging.getLogger(__name__)
@@ -106,10 +107,18 @@ class DataLoader(object):
                         content = _readfile(url)
                     else:
                         logger.info('[attempt=%s/%s] loading data from url=%s' % (trial, nretry, url))
+
                         try:
-                            content = urllib.request.urlopen(url, timeout=20).read()  # Python 3
+                            req = urllib.request.Request(url)  # Python 3
                         except Exception:
-                            content = urllib2.urlopen(url, timeout=20).read()  # Python 2
+                            req = urllib2.Request(url)  # Python 2
+
+                        req.add_header('User-Agent', ctx.user_agent)
+
+                        try:
+                            content = urllib.request.urlopen(req, context=ctx.ssl_context, timeout=20).read()  # Python 3
+                        except Exception:
+                            content = urllib2.urlopen(req, context=ctx.ssl_context, timeout=20).read()  # Python 2
                     if fname:  # save to cache
                         with open(fname, "w+") as f:
                             f.write(str(content))  # Python 3, added str (write() argument must be str, not bytes; JSON OK)

--- a/pilot/info/extinfo.py
+++ b/pilot/info/extinfo.py
@@ -52,7 +52,7 @@ class ExtInfoProvider(DataLoader):
         :return:
         """
 
-        pandaqueues = set(pandaqueues)
+        pandaqueues = sorted(set(pandaqueues))
 
         cache_dir = config.Information.cache_dir
         if not cache_dir:
@@ -67,7 +67,7 @@ class ExtInfoProvider(DataLoader):
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours
                             'fname': os.path.join(cache_dir, 'agis_schedconf.agis.%s.json' %
-                                                  ('_'.join(sorted(pandaqueues)) or 'ALL'))},
+                                                  ('_'.join(pandaqueues) or 'ALL'))},
                    'LOCAL': {'url': os.environ.get('LOCAL_AGIS_SCHEDCONF', None),
                              'nretry': 1,
                              'cache_time': 3 * 60 * 60,  # 3 hours
@@ -123,7 +123,7 @@ class ExtInfoProvider(DataLoader):
                              'fname': os.path.join(cache_dir, config.Information.queuedata_cache or 'queuedata.json'),
                              'parser': jsonparser_panda
                              },
-                   'PANDA': {'url': config.Information.queuedata_url % {'pandaqueue': pandaqueues[0]},
+                   'PANDA': {'url': config.Information.queuedata_url.format(**{'pandaqueue': pandaqueues[0]}),
                              'nretry': 3,
                              'sleep_time': lambda: 15 + random.randint(0, 30),  # max sleep time 45 seconds between retries
                              'cache_time': 3 * 60 * 60,  # 3 hours,
@@ -147,7 +147,7 @@ class ExtInfoProvider(DataLoader):
         :return: dict of DDMEndpoint settings by DDMendpoint name as a key
         """
 
-        ddmendpoints = set(ddmendpoints)
+        ddmendpoints = sorted(set(ddmendpoints))
 
         cache_dir = config.Information.cache_dir
         if not cache_dir:
@@ -163,7 +163,7 @@ class ExtInfoProvider(DataLoader):
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours
                             'fname': os.path.join(cache_dir, 'agis_ddmendpoints.agis.%s.json' %
-                                                  ('_'.join(sorted(ddmendpoints)) or 'ALL'))},
+                                                  ('_'.join(ddmendpoints) or 'ALL'))},
                    'LOCAL': {'url': None,
                              'nretry': 1,
                              'cache_time': 3 * 60 * 60,  # 3 hours

--- a/pilot/info/extinfo.py
+++ b/pilot/info/extinfo.py
@@ -68,7 +68,7 @@ class ExtInfoProvider(DataLoader):
                             'cache_time': 3 * 60 * 60,  # 3 hours
                             'fname': os.path.join(cache_dir, 'agis_schedconf.agis.%s.json' %
                                                   ('_'.join(pandaqueues) or 'ALL'))},
-                   'LOCAL': {'url': os.environ.get('LOCAL_AGIS_SCHEDCONF', None),
+                   'LOCAL': {'url': os.environ.get('LOCAL_AGIS_SCHEDCONF'),
                              'nretry': 1,
                              'cache_time': 3 * 60 * 60,  # 3 hours
                              'fname': os.path.join(cache_dir, config.Information.queues_cache or 'agis_schedconf.json')},
@@ -123,7 +123,7 @@ class ExtInfoProvider(DataLoader):
                              'fname': os.path.join(cache_dir, config.Information.queuedata_cache or 'queuedata.json'),
                              'parser': jsonparser_panda
                              },
-                   'PANDA': {'url': config.Information.queuedata_url.format(**{'pandaqueue': pandaqueues[0]}),
+                   'PANDA': {'url': (os.environ.get('QUEUEDATA_SERVER_URL') or config.Information.queuedata_url).format(**{'pandaqueue': pandaqueues[0]}),
                              'nretry': 3,
                              'sleep_time': lambda: 15 + random.randint(0, 30),  # max sleep time 45 seconds between retries
                              'cache_time': 3 * 60 * 60,  # 3 hours,

--- a/pilot/info/extinfo.py
+++ b/pilot/info/extinfo.py
@@ -156,7 +156,7 @@ class ExtInfoProvider(DataLoader):
         # list of sources to fetch ddmconf data from
         sources = {'CVMFS': {'url': config.Information.storages_cvmfs or '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_ddmendpoints.json',
                              'nretry': 1,
-                             'fname': os.path.join(cache_dir, 'agis_ddmendpoints.json')},
+                             'fname': os.path.join(cache_dir, config.Information.storages_cache or 'agis_ddmendpoints.json')},
                    'CRIC': {'url': (config.Information.storages_url or 'https://atlas-cric.cern.ch/api/atlas/ddmendpoint/query/?json') +
                             '&ddmendpoint[]='.join([''] + ddmendpoints),
                             'nretry': 3,

--- a/pilot/info/extinfo.py
+++ b/pilot/info/extinfo.py
@@ -62,7 +62,7 @@ class ExtInfoProvider(DataLoader):
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_schedconf.cvmfs.json')},
                    'CRIC': {'url': (config.Information.queues_url or 'https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json') +
-                                   '&pandaqueue[]='.join([''] + pandaqueues),
+                            '&pandaqueue[]='.join([''] + pandaqueues),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours
@@ -111,7 +111,7 @@ class ExtInfoProvider(DataLoader):
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_schedconf.cvmfs.json')},
                    'CRIC': {'url': (config.Information.queues_url or 'https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json') +
-                                   '&pandaqueue[]='.join([''] + pandaqueues),
+                            '&pandaqueue[]='.join([''] + pandaqueues),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  # max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours
@@ -158,7 +158,7 @@ class ExtInfoProvider(DataLoader):
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_ddmendpoints.json')},
                    'CRIC': {'url': (config.Information.storages_url or 'https://atlas-cric.cern.ch/api/atlas/ddmendpoint/query/?json') +
-                                   '&ddmendpoint[]='.join([''] + ddmendpoints),
+                            '&ddmendpoint[]='.join([''] + ddmendpoints),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours

--- a/pilot/info/extinfo.py
+++ b/pilot/info/extinfo.py
@@ -58,11 +58,11 @@ class ExtInfoProvider(DataLoader):
         if not cache_dir:
             cache_dir = os.environ.get('PILOT_HOME', '.')
 
-        sources = {'CVMFS': {'url': '/cvmfs/atlas.cern.ch/repo/sw/local/etc/agis_schedconf.json',
+        sources = {'CVMFS': {'url': '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json',
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_schedconf.cvmfs.json')},
-                   'AGIS': {'url': 'http://atlas-agis-api.cern.ch/request/pandaqueue/query/list/?json'
-                                   '&preset=schedconf.all&panda_queue=%s' % ','.join(pandaqueues),
+                   'AGIS': {'url': 'https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json' +
+                                   '&pandaqueue[]='.join([''] + pandaqueues),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours
@@ -108,11 +108,11 @@ class ExtInfoProvider(DataLoader):
                 raise Exception('response contains error, data=%s' % dat)
             return {pandaqueue: dat}
 
-        sources = {'CVMFS': {'url': '/cvmfs/atlas.cern.ch/repo/sw/local/etc/agis_schedconf.json',
+        sources = {'CVMFS': {'url': '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json',
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_schedconf.cvmfs.json')},
-                   'AGIS': {'url': 'http://atlas-agis-api.cern.ch/request/pandaqueue/query/list/?json'
-                                   '&preset=schedconf.all&panda_queue=%s' % ','.join(pandaqueues),
+                   'AGIS': {'url': 'https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json' +
+                                   '&pandaqueue[]='.join([''] + pandaqueues),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  # max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours
@@ -173,11 +173,11 @@ class ExtInfoProvider(DataLoader):
             cache_dir = os.environ.get('PILOT_HOME', '.')
 
         # list of sources to fetch ddmconf data from
-        sources = {'CVMFS': {'url': '/cvmfs/atlas.cern.ch/repo/sw/local/etc/agis_ddmendpoints.json',
+        sources = {'CVMFS': {'url': '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_ddmendpoints.json',
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_ddmendpoints.json')},
-                   'AGIS': {'url': 'http://atlas-agis-api.cern.ch/request/ddmendpoint/query/list/?json&'
-                                   'state=ACTIVE&preset=dict&ddmendpoint=%s' % ','.join(ddmendpoints),
+                   'AGIS': {'url': 'https://atlas-cric.cern.ch/api/atlas/ddmendpoint/query/?json' +
+                                   '&ddmendpoint[]='.join([''] + ddmendpoints),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours

--- a/pilot/info/infoservice.py
+++ b/pilot/info/infoservice.py
@@ -192,7 +192,7 @@ class InfoService(object):
             and failover to default value (LOCAL, CVMFS, AGIS, PANDA)
         """
 
-        defval = ['LOCAL', 'CVMFS', 'AGIS', 'PANDA']
+        defval = ['LOCAL', 'CVMFS', 'CRIC', 'PANDA']
 
         # look up priority order: either from job, local config or hardcoded in the logic
         return self._resolve_data(self.whoami(), providers=(self.confinfo, self.jobinfo)) or defval

--- a/pilot/util/default.cfg
+++ b/pilot/util/default.cfg
@@ -126,17 +126,27 @@ utility_with_stagein:
 #cache_dir:  /lustre/atlas/proj-shared/csc108/debug/atlas/HPC_pilot_test/queue_cache #for Titan
 cache_dir:
 
-# URL for the PanDA queues json
-queues: http://atlas-agis-api.cern.ch/request/pandaqueue/query/list/?json
+# default URL value for primary source of Queuedata (can be overwritten via --queuedata-url option)
+queuedata_url: http://pandaserver.cern.ch:25085/cache/schedconfig/%(pandaqueue)s.all.json
+# path to queuedata JSON provided by shared filesystem
+queuedata_cvmfs: /cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json
+# local cache filename of the queuedata json
+queuedata_cache: queuedata.json
 
-# URL for the DDM endpoints json
-storages: http://atlas-agis-api.cern.ch/request/ddmendpoint/query/list/?json
+# URL for the PanDA queues API provided by Information system
+queues_url: https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json
+# path to PanDA queues JSON provided by shared filesystem
+queues_cvmfs: /cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json
+# file name of local cache for the PanDA queues JSON
+queues_cache: cric_pandaqueues.json
 
-# URL for the SchedConfig json
-schedconfig: http://pandaserver.cern.ch:25085/cache/schedconfig
+# URL for the DDMEndpoints/storages API provided by Information system
+storages_url: https://atlas-cric.cern.ch/api/atlas/ddmendpoint/query/?json
+# path to storages JSON cache provided by shared filesystem
+storages_cvmfs: /cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_ddmendpoints.json
+# file name of local cache for the storages JSON
+storages_cache: cric_ddmendpoints.json
 
-# File name for the queuedata json
-queuedata: queuedata.json
 
 # overwrite acopytools for queuedata
 #acopytools: {'pr':['rucio']}

--- a/pilot/util/default.cfg
+++ b/pilot/util/default.cfg
@@ -127,7 +127,7 @@ utility_with_stagein:
 cache_dir:
 
 # default URL value for primary source of Queuedata (can be overwritten via --queuedata-url option)
-queuedata_url: "http://pandaserver.cern.ch:25085/cache/schedconfig/{pandaqueue}.all.json"
+queuedata_url: http://pandaserver.cern.ch:25085/cache/schedconfig/{pandaqueue}.all.json
 # path to queuedata JSON provided by shared filesystem
 queuedata_cvmfs: /cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json
 # local cache filename of the queuedata json

--- a/pilot/util/default.cfg
+++ b/pilot/util/default.cfg
@@ -129,9 +129,6 @@ cache_dir:
 # URL for the PanDA queues json
 queues: http://atlas-agis-api.cern.ch/request/pandaqueue/query/list/?json
 
-# URL for the sites json
-sites: http://atlas-agis-api.cern.ch/request/site/query/list/?json
-
 # URL for the DDM endpoints json
 storages: http://atlas-agis-api.cern.ch/request/ddmendpoint/query/list/?json
 

--- a/pilot/util/default.cfg
+++ b/pilot/util/default.cfg
@@ -127,7 +127,7 @@ utility_with_stagein:
 cache_dir:
 
 # default URL value for primary source of Queuedata (can be overwritten via --queuedata-url option)
-queuedata_url: http://pandaserver.cern.ch:25085/cache/schedconfig/%(pandaqueue)s.all.json
+queuedata_url: "http://pandaserver.cern.ch:25085/cache/schedconfig/{pandaqueue}.all.json"
 # path to queuedata JSON provided by shared filesystem
 queuedata_cvmfs: /cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json
 # local cache filename of the queuedata json

--- a/pilot/util/https.py
+++ b/pilot/util/https.py
@@ -37,6 +37,9 @@ logger = logging.getLogger(__name__)
 
 _ctx = collections.namedtuple('_ctx', 'ssl_context user_agent capath cacert')
 
+# anisyonk: public copy of `_ctx` to avoid logic break since ssl_context is reset inside the request() -- FIXME
+ctx = collections.namedtuple('ctx', 'ssl_context user_agent capath cacert')
+
 
 def _tester(func, *args):
     """
@@ -132,7 +135,7 @@ def https_setup(args, version):
     _ctx.capath = capath(args)
     _ctx.cacert = cacert(args)
 
-    if sys.version_info < (2, 7, 9):
+    if sys.version_info < (2, 7, 9):  # by anisyonk: actually SSL context should work, but prior to 2.7.9 there is no automatic hostname/certificate validation
         logger.warn('Python version <2.7.9 lacks SSL contexts -- falling back to curl')
         _ctx.ssl_context = None
     else:
@@ -142,6 +145,17 @@ def https_setup(args, version):
         except Exception as e:
             logger.warn('SSL communication is impossible due to SSL error: %s -- falling back to curl' % str(e))
             _ctx.ssl_context = None
+
+    # anisyonk: clone `_ctx` to avoid logic break since ssl_context is reset inside the request() -- FIXME
+    ctx.capath = _ctx.capath
+    ctx.cacert = _ctx.cacert
+    ctx.user_agent = _ctx.user_agent
+
+    try:
+        ctx.ssl_context = ssl.create_default_context(capath=ctx.capath, cafile=ctx.cacert)
+        ctx.ssl_context.load_cert_chain(ctx.cacert)
+    except Exception as e:  ## redandant try-catch protection, should work well for both python2 & python3 (anisyonk)
+        logger.warn('Failed to initialize SSL context .. skipped, error: %s' % str(e))
 
 
 def request(url, data=None, plain=False, secure=True):  # noqa: C901

--- a/pilot/util/https.py
+++ b/pilot/util/https.py
@@ -31,6 +31,7 @@ import pipes
 
 from .filehandling import write_file
 from .auxiliary import is_python3
+from .constants import get_pilot_version
 
 import logging
 logger = logging.getLogger(__name__)
@@ -38,8 +39,9 @@ logger = logging.getLogger(__name__)
 _ctx = collections.namedtuple('_ctx', 'ssl_context user_agent capath cacert')
 
 # anisyonk: public copy of `_ctx` to avoid logic break since ssl_context is reset inside the request() -- FIXME
-ctx = collections.namedtuple('ctx', 'ssl_context user_agent capath cacert')
-
+# anisyonk: public instance, should be properly initialized by `https_setup()`
+# anisyonk: use lightweight class definition instead of namedtuple since tuple is immutable and we don't need/use any tuple features here
+ctx = type('ctx', (object,), dict(ssl_context=None, user_agent='Pilot2 client', capath=None, cacert=None))
 
 def _tester(func, *args):
     """
@@ -115,7 +117,7 @@ def cacert(args=None):
                    cacert_default_location())
 
 
-def https_setup(args, version):
+def https_setup(args=None, version=None):
     """
     Sets up the context for future HTTPS requests:
 
@@ -126,6 +128,9 @@ def https_setup(args, version):
     :param args: arguments, parsed by `argparse`
     :param str version: pilot version string (for :mailheader:`User-Agent`)
     """
+
+    version = version or get_pilot_version()
+
     _ctx.user_agent = 'pilot/%s (Python %s; %s %s)' % (version,
                                                        sys.version.split()[0],
                                                        platform.system(),
@@ -154,7 +159,7 @@ def https_setup(args, version):
     try:
         ctx.ssl_context = ssl.create_default_context(capath=ctx.capath, cafile=ctx.cacert)
         ctx.ssl_context.load_cert_chain(ctx.cacert)
-    except Exception as e:  ## redandant try-catch protection, should work well for both python2 & python3 (anisyonk)
+    except Exception as e:  # redandant try-catch protection, should work well for both python2 & python3 -- CLEAN ME later (anisyonk)
         logger.warn('Failed to initialize SSL context .. skipped, error: %s' % str(e))
 
 


### PR DESCRIPTION
1. Migrate Pilot to use `CRIC` API & CVMFS caches published by `CRIC` instead of `AGIS` source.

2. in addition following updates have been applied:

-  upgrade `pilot.info.DataLoader` to use authenticated SSL access to query information system with pilot's certificate passed
-  make `pilot.info` configurable for a `VO`: allow to specify custom input JSON data from external information sources (isolate locations of queuedata/queues/storages/cvmfs JSONs into the config file)
- update `pilot.utils.https`: add proper `SSL` context initialization in  `https_setup`

**Notes for automatic passing client certificates**:

`pilot.info.DataLoader` uses global ssl context settings `ctx` which is initialized by `https_setup()` from `pilot.utils.https`. So that to get pilot SSL certificate properly being  passed while querying API of affected Information system somebody should execute `https_setup` function at the beginning. If `https_setup()`  is not applied, then all will work well until ext infosys allows guest/unauthorized access to API.

1. for regular pilot run via CLI all should work out of the box since `https_setup()` is automatically executed when pilot started with enabled by default --use-https input option
2.  in case of using Pilot Data API, for example by `Harvester`, somebody should manually initialize ssl context:

```python
from pilot.util.https import https_setup
from pilot.info import infosys

https_setup()

infosys.init('AGLT2_HOSPITAL')
```

for custom locations of CA path and X509 certificate

```python
from pilot.util.https import https_setup

import collections
args = collections.namedtuple('args', 'capath cacert')
https_setup(args(capath='/etc/grid-security/custom-certificates', cacert='/path/to/certkey.pem'))
```


