### PR TITLE
pilot.info: ignore missing entries in the Pilot configuration

### DIFF
--- a/pilot/info/extinfo.py
+++ b/pilot/info/extinfo.py
@@ -59,10 +59,10 @@ class ExtInfoProvider(DataLoader):
         if not cache_dir:
             cache_dir = os.environ.get('PILOT_HOME', '.')
 
-        sources = {'CVMFS': {'url': config.Information.queues_cvmfs or '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json',
+        sources = {'CVMFS': {'url': getattr(config.Information, 'queues_cvmfs', None) or '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json',
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_schedconf.cvmfs.json')},
-                   'CRIC': {'url': (config.Information.queues_url or 'https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json') +
+                   'CRIC': {'url': (getattr(config.Information, 'queues_url', None) or 'https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json') +
                             '&pandaqueue[]='.join([''] + pandaqueues),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
@@ -72,7 +72,7 @@ class ExtInfoProvider(DataLoader):
                    'LOCAL': {'url': os.environ.get('LOCAL_AGIS_SCHEDCONF'),
                              'nretry': 1,
                              'cache_time': 3 * 60 * 60,  # 3 hours
-                             'fname': os.path.join(cache_dir, config.Information.queues_cache or 'agis_schedconf.json')},
+                             'fname': os.path.join(cache_dir, getattr(config.Information, 'queues_cache', None) or 'agis_schedconf.json')},
                    'PANDA': None  ## NOT implemented, FIX ME LATER
                    }
 
@@ -108,10 +108,12 @@ class ExtInfoProvider(DataLoader):
                 raise Exception('response contains error, data=%s' % dat)
             return {pandaqueue: dat}
 
-        sources = {'CVMFS': {'url': config.Information.queuedata_cvmfs or '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json',
+        queuedata_url = (os.environ.get('QUEUEDATA_SERVER_URL') or getattr(config.Information, 'queuedata_url', '')).format(**{'pandaqueue': pandaqueues[0]})
+
+        sources = {'CVMFS': {'url': getattr(config.Information, 'queuedata_cvmfs', None) or '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json',
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_schedconf.cvmfs.json')},
-                   'CRIC': {'url': (config.Information.queues_url or 'https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json') +
+                   'CRIC': {'url': (getattr(config.Information, 'queues_url', None) or 'https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json') +
                             '&pandaqueue[]='.join([''] + pandaqueues),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  # max sleep time 45 seconds between retries
@@ -121,14 +123,14 @@ class ExtInfoProvider(DataLoader):
                    'LOCAL': {'url': None,
                              'nretry': 1,
                              'cache_time': 3 * 60 * 60,  # 3 hours
-                             'fname': os.path.join(cache_dir, config.Information.queuedata_cache or 'queuedata.json'),
+                             'fname': os.path.join(cache_dir, getattr(config.Information, 'queuedata_cache', None) or 'queuedata.json'),
                              'parser': jsonparser_panda
                              },
-                   'PANDA': {'url': (os.environ.get('QUEUEDATA_SERVER_URL') or config.Information.queuedata_url).format(**{'pandaqueue': pandaqueues[0]}),
+                   'PANDA': {'url': queuedata_url,
                              'nretry': 3,
                              'sleep_time': lambda: 15 + random.randint(0, 30),  # max sleep time 45 seconds between retries
                              'cache_time': 3 * 60 * 60,  # 3 hours,
-                             'fname': os.path.join(cache_dir, config.Information.queuedata_cache or 'queuedata.json'),
+                             'fname': os.path.join(cache_dir, getattr(config.Information, 'queuedata_cache', None) or 'queuedata.json'),
                              'parser': jsonparser_panda
                              }
                    }
@@ -157,8 +159,8 @@ class ExtInfoProvider(DataLoader):
         # list of sources to fetch ddmconf data from
         sources = {'CVMFS': {'url': config.Information.storages_cvmfs or '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_ddmendpoints.json',
                              'nretry': 1,
-                             'fname': os.path.join(cache_dir, config.Information.storages_cache or 'agis_ddmendpoints.json')},
-                   'CRIC': {'url': (config.Information.storages_url or 'https://atlas-cric.cern.ch/api/atlas/ddmendpoint/query/?json') +
+                             'fname': os.path.join(cache_dir, getattr(config.Information, 'storages_cache', None) or 'agis_ddmendpoints.json')},
+                   'CRIC': {'url': (getattr(config.Information, 'storages_url', None) or 'https://atlas-cric.cern.ch/api/atlas/ddmendpoint/query/?json') +
                             '&ddmendpoint[]='.join([''] + ddmendpoints),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
@@ -168,7 +170,7 @@ class ExtInfoProvider(DataLoader):
                    'LOCAL': {'url': None,
                              'nretry': 1,
                              'cache_time': 3 * 60 * 60,  # 3 hours
-                             'fname': os.path.join(cache_dir, config.Information.storages_cache or 'agis_ddmendpoints.json')},
+                             'fname': os.path.join(cache_dir, getattr(config.Information, 'storages_cache', None) or 'agis_ddmendpoints.json')},
                    'PANDA': None  ## NOT implemented, FIX ME LATER if need
                    }
 


### PR DESCRIPTION
Fix issue with missing new (CRIC related) entries in old configuration file used by clients (HPC affected issue)

