### PR TITLE
Cacertbugfix

### DIFF
--- a/pilot/util/https.py
+++ b/pilot/util/https.py
@@ -80,7 +80,7 @@ def capath(args=None):
     """
 
     return _tester(os.path.isdir,
-                   None if args is None or args.capath is None else args.capath,
+                   args and args.capath,
                    os.environ.get('X509_CERT_DIR'),
                    '/etc/grid-security/certificates')
 
@@ -114,7 +114,7 @@ def cacert(args=None):
     """
 
     return _tester(os.path.isfile,
-                   None if args is None or args.cacert is None else args.capath,
+                   args and args.cacert,
                    os.environ.get('X509_USER_PROXY'),
                    cacert_default_location())
 


### PR DESCRIPTION
bugfix in `cacert()` function: properly consider `--cacert` option to be used for certificate lookup/verification instead of `--capath`

This fix should affect only pilots run with custom `--capath` and `--cacert` input CLI arguments (HPC?) 

Regular pilots should not be affected since they I believe use `X509_USER_PROXY` environ.
