### PR TITLE
Fx batchsystem jobid extraction with HTCondor

### DIFF
--- a/pilot/util/auxiliary.py
+++ b/pilot/util/auxiliary.py
@@ -132,7 +132,7 @@ def get_batchsystem_jobid():
         except Exception:
             from subprocess import getoutput  # Python 3
         return "Condor", getoutput(
-            'sed -n "s/GlobalJobId.*\\"\\(.*\\)\\".*/\\1/p" %s' % os.environ.get("_CONDOR_JOB_AD"))
+            'sed -n "s/^GlobalJobId.*\\"\\(.*\\)\\".*/\\1/p" %s' % os.environ.get("_CONDOR_JOB_AD"))
 
     return None, ""
 


### PR DESCRIPTION
HTCondor classads may contain multiple attributes matching the pattern, e.g.:
```
GlobalJobId = "cloud-htcondor-ce-1-kit.gridka.de#46794.0#1606743653"
SubmitterGlobalJobId = "aipanda184.cern.ch#7873849.0#1606743625" 
```
With the current pattern, this would be resolved to the exceptionally long string:
```
Submitteraipanda184.cern.ch#7873849.0#1606743625 \ncloud-htcondor-ce-1-kit.gridka.de#46794.0#1606743653
```
Worse, since the order of the attributes is not guaranteed, it may also be resolved to:
```
cloud-htcondor-ce-1-kit.gridka.de#46794.0#1606743653\nSubmitteraipanda184.cern.ch#7873849.0#1606743625 
```
Due to the ambiguity, we have observed many jobs being killed with:
```
got an update request with invalid batchID=cloud-htcondor-ce-1-kit.gridka.de#42815.0#1606603131Submitteraipanda184.cern.ch
```

Assuming `GlobalJobId` was intended, this commit adapts the expression to filter for classad attributes starting with this pattern.