### PR TITLE
new feature:

### DIFF
--- a/pilot/user/atlas/container.py
+++ b/pilot/user/atlas/container.py
@@ -316,7 +316,7 @@ def update_for_user_proxy(_cmd, cmd):
             logger.info("payload proxy was received")
 
             logger.info("verify payload proxy...")
-            exit_code, diagnostics = verify_proxy(x509=x509_payload)
+            exit_code, diagnostics = verify_proxy(x509=x509_payload, proxy_id='payload')
             # if all verifications fail, verify_proxy()  returns exit_code=0 and last failure in diagnostics
             if exit_code != 0 or (exit_code == 0 and diagnostics != ''):
                 logger.warning(diagnostics)

--- a/pilot/user/atlas/container.py
+++ b/pilot/user/atlas/container.py
@@ -50,12 +50,23 @@ def get_payload_proxy(proxy_outfile_name, voms_role='atlas'):
             return False
 
         proxy_contents = res['userProxy']
-
+        
     except Exception as e:
         logger.error("Get proxy from panda server failed: %s, %s" % (e, traceback.format_exc()))
         return False
 
-    return write_file(proxy_outfile_name, proxy_contents, mute=False)
+    res = False;
+    try:
+        # pre-create empty proxy file with secure permissions. Prepare it for write_file() which can not 
+        # set file permission mode, it will writes to the existing file with correct permissions.
+        f=os.open(proxy_outfile_name, os.O_WRONLY|os.O_CREAT|os.O_TRUNC, 0o600)
+        os.close(f)
+        res = write_file(proxy_outfile_name, proxy_contents, mute=False)  # returns True on success
+    except Exception as e:
+        logger.error("Exception when try to save proxy to the file '%s': %s, %s" % (proxy_outfile_name, e, traceback.format_exc()))
+        raise FileHandlingFailure(e)
+        
+    return res 
 
 
 def do_use_container(**kwargs):

--- a/pilot/user/atlas/container.py
+++ b/pilot/user/atlas/container.py
@@ -50,23 +50,22 @@ def get_payload_proxy(proxy_outfile_name, voms_role='atlas'):
             return False
 
         proxy_contents = res['userProxy']
-        
+
     except Exception as e:
         logger.error("Get proxy from panda server failed: %s, %s" % (e, traceback.format_exc()))
         return False
 
-    res = False;
+    res = False
     try:
-        # pre-create empty proxy file with secure permissions. Prepare it for write_file() which can not 
+        # pre-create empty proxy file with secure permissions. Prepare it for write_file() which can not
         # set file permission mode, it will writes to the existing file with correct permissions.
-        f=os.open(proxy_outfile_name, os.O_WRONLY|os.O_CREAT|os.O_TRUNC, 0o600)
+        f = os.open(proxy_outfile_name, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         os.close(f)
         res = write_file(proxy_outfile_name, proxy_contents, mute=False)  # returns True on success
     except Exception as e:
         logger.error("Exception when try to save proxy to the file '%s': %s, %s" % (proxy_outfile_name, e, traceback.format_exc()))
-        raise FileHandlingFailure(e)
-        
-    return res 
+
+    return res
 
 
 def do_use_container(**kwargs):

--- a/pilot/user/atlas/proxy.py
+++ b/pilot/user/atlas/proxy.py
@@ -106,7 +106,7 @@ def verify_arcproxy(envsetup, limit, proxy_id="pilot"):
                 tnow = int(time() + 0.5)  # round to seconds
                 seconds_left = validity_end - tnow
                 logger.info("cache: check '%s' proxy validity: wanted=%dh left=%.2fh (now=%d validity_end=%d left=%d)"
-                            % (proxy_id, limit, float(seconds_left)/3600, tnow, validity_end, seconds_left))
+                            % (proxy_id, limit, float(seconds_left) / 3600, tnow, validity_end, seconds_left))
                 if seconds_left < limit * 3600:
                     logger.info("'%s' proxy validity time is too short" % (proxy_id))
                     ec = -1
@@ -269,7 +269,7 @@ def interpret_proxy_info(ec, stdout, stderr, limit):
             try:
                 validity_end_str = stdout_split[-2]  # imay raise exception IndexError if stdout is too short
                 logger.debug("try to get validity_end from the line: \"%s\"" % validity_end_str)
-                validity_end = int(validity_end_str) # may raise ValueError if not string
+                validity_end = int(validity_end_str)  # may raise ValueError if not string
                 logger.info("validity_end = %d" % (validity_end))
             except (IndexError, ValueError) as err:
                 logger.info("validity_end not found in stdout (%s)" % err)

--- a/pilot/user/atlas/proxy.py
+++ b/pilot/user/atlas/proxy.py
@@ -6,6 +6,7 @@
 #
 # Authors:
 # - Paul Nilsson, paul.nilsson@cern.ch, 2018
+# - Alexander Bogdanchikov, Alexander.Bogdanchikov@cern.ch, 2020
 
 # from pilot.util.container import execute
 
@@ -34,7 +35,7 @@ def verify_proxy(limit=None, x509=None, proxy_id="pilot"):
     exit_code = 0
     diagnostics = ""
 
-    logger.info("verify_proxy() begin")
+    logger.debug("verify_proxy() begin")
 
     if limit is None:
         limit = 48
@@ -90,30 +91,29 @@ def verify_arcproxy(envsetup, limit, proxy_id="pilot"):
     ec = 0
     diagnostics = ""
 
-    logger.info("verify_arcproxy() begin")
+    logger.debug("verify_arcproxy() begin")
 
-    if proxy_id != None:
+    if proxy_id is not None:
         if not hasattr(verify_arcproxy, "cache"):
-            verify_arcproxy.cache={}
+            verify_arcproxy.cache = {}
         logger.info("current cache=%s" % (verify_arcproxy.cache))
-        if proxy_id in verify_arcproxy.cache: # if exist, then calculate result from current cache
+        if proxy_id in verify_arcproxy.cache:  # if exist, then calculate result from current cache
             validity_end = verify_arcproxy.cache[proxy_id]
-            if validity_end < 0: # previous validity check failed, do not try to re-check
+            if validity_end < 0:  # previous validity check failed, do not try to re-check
                 ec = -1
                 diagnostics = "arcproxy verification failed (cached result)"
             else:
-                tnow = int ( time() + 0.5 ) # round to seconds
+                tnow = int(time() + 0.5)  # round to seconds
                 seconds_left = validity_end - tnow
-                logger.info("cache: check '%s' proxy validity: wanted=%dh left=%.2fh (now=%d validity_end=%d left=%d)"  \
-                    % (proxy_id, tnow, seconds_left/3600, validity_end, limit,  seconds_left))))
+                logger.info("cache: check '%s' proxy validity: wanted=%dh left=%.2fh (now=%d validity_end=%d left=%d)"
+                            % (proxy_id, limit, float(seconds_left)/3600, tnow, validity_end, seconds_left))
                 if seconds_left < limit * 3600:
-                    logger.info("proxy validity time is too short")
+                    logger.info("'%s' proxy validity time is too short" % (proxy_id))
                     ec = -1
                     diagnostics = "validity time is too short"
                 else:
-                    logger.info("proxy validity time is enough")
+                    logger.info("'%s' proxy validity time is enough" % (proxy_id))
             return ec, diagnostics
-        
 
     # options and options' sequence are important for parsing, do not change it
     cmd = "%sarcproxy -i vomsACvalidityEnd -i vomsACvalidityLeft" % (envsetup)
@@ -126,12 +126,12 @@ def verify_arcproxy(envsetup, limit, proxy_id="pilot"):
             ec = -1
         else:
             ec, diagnostics, validity_end = interpret_proxy_info(exit_code, stdout, stderr, limit)
-            if proxy_id and validity_end: # setup cache if requered
+            if proxy_id and validity_end:  # setup cache if requered
                 if ec == 0:
                     logger.info("cache the validity_end: cache['%s'] = %d" % (proxy_id, validity_end))
                     verify_arcproxy.cache[proxy_id] = validity_end
-                else: 
-                    verify_arcproxy.cache[proxy_id] = -1 # -1 in cache means any error in prev validation
+                else:
+                    verify_arcproxy.cache[proxy_id] = -1  # -1 in cache means any error in prev validation
             if ec == 0:
                 logger.info("voms proxy verified using arcproxy")
                 return 0, diagnostics
@@ -160,7 +160,7 @@ def verify_vomsproxy(envsetup, limit):
     ec = 0
     diagnostics = ""
 
-    logger.info("verify_arcproxy() begin")
+    logger.debug("verify_arcproxy() begin")
 
     if os.environ.get('X509_USER_PROXY', '') != '':
         cmd = "%svoms-proxy-info -actimeleft --file $X509_USER_PROXY" % (envsetup)
@@ -236,7 +236,7 @@ def interpret_proxy_info(ec, stdout, stderr, limit):
 
     exitcode = 0
     diagnostics = ""
-    validity_end = None # not detected
+    validity_end = None  # not detected
 
     logger.debug('stdout = %s' % stdout)
     logger.debug('stderr = %s' % stderr)
@@ -267,12 +267,12 @@ def interpret_proxy_info(ec, stdout, stderr, limit):
             logger.debug("splitted stdout = %s" % (stdout_split))
             # try to get validity_end in penult line, it may fail, throw exception
             try:
-                validity_end_str = stdout_split[-2] # it mail fail=except if result is too short
+                validity_end_str = stdout_split[-2]  # imay raise exception IndexError if stdout is too short
                 logger.debug("try to get validity_end from the line: \"%s\"" % validity_end_str)
-                validity_end = int (validity_end_str) 
+                validity_end = int(validity_end_str) # may raise ValueError if not string
                 logger.info("validity_end = %d" % (validity_end))
-            except:
-                logger.info("failed to get validity_end")
+            except (IndexError, ValueError) as err:
+                logger.info("validity_end not found in stdout (%s)" % err)
                 pass
             stdout = stdout_split[-1]  # remove everything except last line
 

--- a/pilot/user/atlas/proxy.py
+++ b/pilot/user/atlas/proxy.py
@@ -15,12 +15,13 @@ import logging
 from pilot.user.atlas.setup import get_file_system_root_path
 from pilot.util.container import execute
 from pilot.common.errorcodes import ErrorCodes
+from time import time
 
 logger = logging.getLogger(__name__)
 errors = ErrorCodes()
 
 
-def verify_proxy(limit=None, x509=None):
+def verify_proxy(limit=None, x509=None, proxy_id="pilot"):
     """
     Check for a valid voms/grid proxy longer than N hours.
     Use `limit` to set required time limit.
@@ -32,6 +33,8 @@ def verify_proxy(limit=None, x509=None):
 
     exit_code = 0
     diagnostics = ""
+
+    logger.info("verify_proxy() begin")
 
     if limit is None:
         limit = 48
@@ -54,7 +57,7 @@ def verify_proxy(limit=None, x509=None):
     # first try to use arcproxy since voms-proxy-info is not working properly on SL6
     #  (memory issues on queues with limited memory)
 
-    ec, diagnostics = verify_arcproxy(envsetup, limit)
+    ec, diagnostics = verify_arcproxy(envsetup, limit, proxy_id)
     if ec != 0 and ec != -1:
         return ec, diagnostics
     elif ec == -1:
@@ -75,28 +78,60 @@ def verify_proxy(limit=None, x509=None):
     return exit_code, diagnostics
 
 
-def verify_arcproxy(envsetup, limit):
+def verify_arcproxy(envsetup, limit, proxy_id="pilot"):
     """
     Verify the proxy using arcproxy.
 
     :param envsetup: general setup string for proxy commands (string).
     :param limit: time limit in hours (int).
+    :param  proxy_id: proxy unique id name. The verification result will be cached for this id. If None the result will not be cached (string)
     :return: exit code (int), error diagnostics (string).
     """
-
     ec = 0
     diagnostics = ""
 
-    cmd = "%sarcproxy -i vomsACvalidityLeft" % (envsetup)
+    logger.info("verify_arcproxy() begin")
 
-    exit_code, stdout, stderr = execute(cmd, shell=True)  #, usecontainer=True, copytool=True)
+    if proxy_id != None:
+        if not hasattr(verify_arcproxy, "cache"):
+            verify_arcproxy.cache={}
+        logger.info("current cache=%s" % (verify_arcproxy.cache))
+        if proxy_id in verify_arcproxy.cache: # if exist, then calculate result from current cache
+            validity_end = verify_arcproxy.cache[proxy_id]
+            if validity_end < 0: # previous validity check failed, do not try to re-check
+                ec = -1
+                diagnostics = "arcproxy verification failed (cached result)"
+            else:
+                tnow = int ( time() + 0.5 ) # round to seconds
+                seconds_left = validity_end - tnow
+                logger.info("cache: check '%s' proxy validity: wanted=%dh left=%.2fh (now=%d validity_end=%d left=%d)"  \
+                    % (proxy_id, tnow, seconds_left/3600, validity_end, limit,  seconds_left))))
+                if seconds_left < limit * 3600:
+                    logger.info("proxy validity time is too short")
+                    ec = -1
+                    diagnostics = "validity time is too short"
+                else:
+                    logger.info("proxy validity time is enough")
+            return ec, diagnostics
+        
+
+    # options and options' sequence are important for parsing, do not change it
+    cmd = "%sarcproxy -i vomsACvalidityEnd -i vomsACvalidityLeft" % (envsetup)
+
+    exit_code, stdout, stderr = execute(cmd, shell=True)  # , usecontainer=True, copytool=True)
     if stdout is not None:
         if 'command not found' in stdout:
             logger.warning("arcproxy is not available on this queue,"
                            "this can lead to memory issues with voms-proxy-info on SL6: %s" % (stdout))
             ec = -1
         else:
-            ec, diagnostics = interpret_proxy_info(exit_code, stdout, stderr, limit)
+            ec, diagnostics, validity_end = interpret_proxy_info(exit_code, stdout, stderr, limit)
+            if proxy_id and validity_end: # setup cache if requered
+                if ec == 0:
+                    logger.info("cache the validity_end: cache['%s'] = %d" % (proxy_id, validity_end))
+                    verify_arcproxy.cache[proxy_id] = validity_end
+                else: 
+                    verify_arcproxy.cache[proxy_id] = -1 # -1 in cache means any error in prev validation
             if ec == 0:
                 logger.info("voms proxy verified using arcproxy")
                 return 0, diagnostics
@@ -125,6 +160,8 @@ def verify_vomsproxy(envsetup, limit):
     ec = 0
     diagnostics = ""
 
+    logger.info("verify_arcproxy() begin")
+
     if os.environ.get('X509_USER_PROXY', '') != '':
         cmd = "%svoms-proxy-info -actimeleft --file $X509_USER_PROXY" % (envsetup)
         logger.info('executing command: %s' % cmd)
@@ -133,7 +170,7 @@ def verify_vomsproxy(envsetup, limit):
             if "command not found" in stdout:
                 logger.info("skipping voms proxy check since command is not available")
             else:
-                ec, diagnostics = interpret_proxy_info(exit_code, stdout, stderr, limit)
+                ec, diagnostics, validity_end = interpret_proxy_info(exit_code, stdout, stderr, limit)
                 if ec == 0:
                     logger.info("voms proxy verified using voms-proxy-info")
                     return 0, diagnostics
@@ -194,11 +231,12 @@ def interpret_proxy_info(ec, stdout, stderr, limit):
     :param stdout: stdout from proxy command (string).
     :param stderr: stderr from proxy command (string).
     :param limit: time limit in hours (int).
-    :return: exit code (int), diagnostics (string).
+    :return: exit code (int), diagnostics (string). validity end in seconds if detected, None if not detected(int)
     """
 
     exitcode = 0
     diagnostics = ""
+    validity_end = None # not detected
 
     logger.debug('stdout = %s' % stdout)
     logger.debug('stderr = %s' % stderr)
@@ -225,7 +263,18 @@ def interpret_proxy_info(ec, stdout, stderr, limit):
             # also remove the last \n in case there is one
             if stdout[-1] == '\n':
                 stdout = stdout[:-1]
-            stdout = stdout.split('\n')[-1]
+            stdout_split = stdout.split('\n')
+            logger.debug("splitted stdout = %s" % (stdout_split))
+            # try to get validity_end in penult line, it may fail, throw exception
+            try:
+                validity_end_str = stdout_split[-2] # it mail fail=except if result is too short
+                logger.debug("try to get validity_end from the line: \"%s\"" % validity_end_str)
+                validity_end = int (validity_end_str) 
+                logger.info("validity_end = %d" % (validity_end))
+            except:
+                logger.info("failed to get validity_end")
+                pass
+            stdout = stdout_split[-1]  # remove everything except last line
 
         # test for command errors
         if "arcproxy:" in stdout:
@@ -250,4 +299,4 @@ def interpret_proxy_info(ec, stdout, stderr, limit):
                 logger.warning(diagnostics)
                 exitcode = errors.GENERALERROR
 
-    return exitcode, diagnostics
+    return exitcode, diagnostics, validity_end


### PR DESCRIPTION
verify_arcproxy() asks and remember validation_end time from the first
"arcproxy" command execution. Repeated verify_arcproxy() calls make
a decision based on the data stored in the cache without "arcproxy"
command execution.

proxy_id parameter is used to identify verification results of various proxies,
by default proxy_id='pilot'. When proxy_id is None, verify_arcproxy() doesn't
use cache and remember results.
Proxies renewals are not expected and not implemented, but such support can be added
later if necessary.