### PR TITLE
Ignore free space check calculation for mv copytool

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -857,10 +857,12 @@ class StageInClient(StagingClient):
         kwargs['activity'] = activity
 
         # verify file sizes and available space for stage-in
-        if self.infosys.queuedata.maxinputsize != -1:
-            self.check_availablespace(remain_files)
-        else:
-            self.logger.info('skipping input file size check since maxinputsize=-1')
+        if getattr(copytool, 'check_availablespace', True):
+            if self.infosys.queuedata.maxinputsize != -1:
+                self.check_availablespace(remain_files)
+            else:
+                self.logger.info('skipping input file size check since maxinputsize=-1')
+
         show_memory_usage()
 
         # add the trace report

--- a/pilot/copytool/mv.py
+++ b/pilot/copytool/mv.py
@@ -19,6 +19,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 require_replicas = False  # indicate if given copytool requires input replicas to be resolved
+check_availablespace = False  # indicate whether space check should be applied before stage-in transfers using given copytool
 
 
 def create_output_list(files, init_dir, ddmconf):


### PR DESCRIPTION
 - make free space check procedure (`check_availablespace`) being optional for specific copytools;
 - ignore the check for `mv` copytool