### PR TITLE
use static JSON caches from CRIC

### DIFF
--- a/pilot/info/extinfo.py
+++ b/pilot/info/extinfo.py
@@ -59,16 +59,19 @@ class ExtInfoProvider(DataLoader):
         if not cache_dir:
             cache_dir = os.environ.get('PILOT_HOME', '.')
 
+        if len(pandaqueues) == 1:
+            cric_url = 'https://atlas-cric.cern.ch/cache/schedconfig/%s.json' % pandaqueues[0]
+        else:
+            cric_url = 'https://atlas-cric.cern.ch/cache/schedconfig/pandaqueues.json'
+
         sources = {'CVMFS': {'url': getattr(config.Information, 'queues_cvmfs', None) or '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json',
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_schedconf.cvmfs.json')},
-                   'CRIC': {'url': (getattr(config.Information, 'queues_url', None) or 'https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json') +
-                            '&pandaqueue[]='.join([''] + pandaqueues),
+                   'CRIC': {'url': (getattr(config.Information, 'queues_url', None) or cric_url),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours
-                            'fname': os.path.join(cache_dir, 'agis_schedconf.agis.%s.json' %
-                                                  ('_'.join(pandaqueues) or 'ALL'))},
+                            'fname': os.path.join(cache_dir, 'agis_schedconf.agis.%s.json' % ('_'.join(pandaqueues) or 'allqueues'))},
                    'LOCAL': {'url': os.environ.get('LOCAL_AGIS_SCHEDCONF'),
                              'nretry': 1,
                              'cache_time': 3 * 60 * 60,  # 3 hours
@@ -110,16 +113,19 @@ class ExtInfoProvider(DataLoader):
 
         queuedata_url = (os.environ.get('QUEUEDATA_SERVER_URL') or getattr(config.Information, 'queuedata_url', '')).format(**{'pandaqueue': pandaqueues[0]})
 
+        if len(pandaqueues) == 1:
+            cric_url = 'https://atlas-cric.cern.ch/cache/schedconfig/%s.json' % pandaqueues[0]
+        else:
+            cric_url = 'https://atlas-cric.cern.ch/cache/schedconfig/pandaqueues.json'
+
         sources = {'CVMFS': {'url': getattr(config.Information, 'queuedata_cvmfs', None) or '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json',
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_schedconf.cvmfs.json')},
-                   'CRIC': {'url': (getattr(config.Information, 'queues_url', None) or 'https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json') +
-                            '&pandaqueue[]='.join([''] + pandaqueues),
+                   'CRIC': {'url': (getattr(config.Information, 'queues_url', None) or cric_url),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  # max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours
-                            'fname': os.path.join(cache_dir, 'agis_schedconf.agis.%s.json' %
-                                                  ('_'.join(sorted(pandaqueues)) or 'ALL'))},
+                            'fname': os.path.join(cache_dir, 'agis_schedconf.agis.%s.json' % ('_'.join(pandaqueues) or 'allqueues'))},
                    'LOCAL': {'url': None,
                              'nretry': 1,
                              'cache_time': 3 * 60 * 60,  # 3 hours
@@ -160,8 +166,7 @@ class ExtInfoProvider(DataLoader):
         sources = {'CVMFS': {'url': config.Information.storages_cvmfs or '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_ddmendpoints.json',
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, getattr(config.Information, 'storages_cache', None) or 'agis_ddmendpoints.json')},
-                   'CRIC': {'url': (getattr(config.Information, 'storages_url', None) or 'https://atlas-cric.cern.ch/api/atlas/ddmendpoint/query/?json') +
-                            '&ddmendpoint[]='.join([''] + ddmendpoints),
+                   'CRIC': {'url': (getattr(config.Information, 'storages_url', None) or 'https://atlas-cric.cern.ch/cache/ddmendpoints.json'),
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours

--- a/pilot/info/extinfo.py
+++ b/pilot/info/extinfo.py
@@ -69,7 +69,7 @@ class ExtInfoProvider(DataLoader):
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours
-                            'fname': os.path.join(cache_dir, 'agis_schedconf.agis.%s.json' % ('_'.join(pandaqueues) or 'allqueues'))},
+                            'fname': os.path.join(cache_dir, 'agis_schedconf.agis.%s.json' % (pandaqueues[0] if len(pandaqueues) == 1 else 'pandaqueues'))},
                    'LOCAL': {'url': os.environ.get('LOCAL_AGIS_SCHEDCONF'),
                              'nretry': 1,
                              'cache_time': 3 * 60 * 60,  # 3 hours
@@ -121,7 +121,7 @@ class ExtInfoProvider(DataLoader):
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  # max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours
-                            'fname': os.path.join(cache_dir, 'agis_schedconf.agis.%s.json' % ('_'.join(pandaqueues) or 'allqueues'))},
+                            'fname': os.path.join(cache_dir, 'agis_schedconf.agis.%s.json' % (pandaqueues[0] if len(pandaqueues) == 1 else 'pandaqueues'))},
                    'LOCAL': {'url': None,
                              'nretry': 1,
                              'cache_time': 3 * 60 * 60,  # 3 hours

--- a/pilot/info/extinfo.py
+++ b/pilot/info/extinfo.py
@@ -4,7 +4,7 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # Authors:
-# - Alexey Anisenkov, anisyonk@cern.ch, 2018
+# - Alexey Anisenkov, anisyonk@cern.ch, 2018-2021
 # - Paul Nilsson, paul.nilsson@cern.ch, 2018-2019
 
 """
@@ -59,15 +59,13 @@ class ExtInfoProvider(DataLoader):
         if not cache_dir:
             cache_dir = os.environ.get('PILOT_HOME', '.')
 
-        if len(pandaqueues) == 1:
-            cric_url = 'https://atlas-cric.cern.ch/cache/schedconfig/%s.json' % pandaqueues[0]
-        else:
-            cric_url = 'https://atlas-cric.cern.ch/cache/schedconfig/pandaqueues.json'
+        cric_url = getattr(config.Information, 'queues_url', None) or 'https://atlas-cric.cern.ch/cache/schedconfig/{pandaqueue}.json'
+        cric_url = cric_url.format(pandaqueue=pandaqueues[0] if len(pandaqueues) == 1 else 'pandaqueues')
 
         sources = {'CVMFS': {'url': getattr(config.Information, 'queues_cvmfs', None) or '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json',
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_schedconf.cvmfs.json')},
-                   'CRIC': {'url': (getattr(config.Information, 'queues_url', None) or cric_url),
+                   'CRIC': {'url': cric_url,
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  ## max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours
@@ -113,15 +111,13 @@ class ExtInfoProvider(DataLoader):
 
         queuedata_url = (os.environ.get('QUEUEDATA_SERVER_URL') or getattr(config.Information, 'queuedata_url', '')).format(**{'pandaqueue': pandaqueues[0]})
 
-        if len(pandaqueues) == 1:
-            cric_url = 'https://atlas-cric.cern.ch/cache/schedconfig/%s.json' % pandaqueues[0]
-        else:
-            cric_url = 'https://atlas-cric.cern.ch/cache/schedconfig/pandaqueues.json'
+        cric_url = getattr(config.Information, 'queues_url', None) or 'https://atlas-cric.cern.ch/cache/schedconfig/{pandaqueue}.json'
+        cric_url = cric_url.format(pandaqueue=pandaqueues[0] if len(pandaqueues) == 1 else 'pandaqueues')
 
         sources = {'CVMFS': {'url': getattr(config.Information, 'queuedata_cvmfs', None) or '/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json',
                              'nretry': 1,
                              'fname': os.path.join(cache_dir, 'agis_schedconf.cvmfs.json')},
-                   'CRIC': {'url': (getattr(config.Information, 'queues_url', None) or cric_url),
+                   'CRIC': {'url': cric_url,
                             'nretry': 3,
                             'sleep_time': lambda: 15 + random.randint(0, 30),  # max sleep time 45 seconds between retries
                             'cache_time': 3 * 60 * 60,  # 3 hours

--- a/pilot/util/default.cfg
+++ b/pilot/util/default.cfg
@@ -149,14 +149,14 @@ queuedata_cvmfs: /cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json
 queuedata_cache: queuedata.json
 
 # URL for the PanDA queues API provided by Information system
-queues_url: https://atlas-cric.cern.ch/api/atlas/pandaqueue/query/?json
+queues_url: https://atlas-cric.cern.ch/cache/schedconfig/pandaqueues.json
 # path to PanDA queues JSON provided by shared filesystem
 queues_cvmfs: /cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json
 # file name of local cache for the PanDA queues JSON
 queues_cache: cric_pandaqueues.json
 
 # URL for the DDMEndpoints/storages API provided by Information system
-storages_url: https://atlas-cric.cern.ch/api/atlas/ddmendpoint/query/?json
+storages_url: https://atlas-cric.cern.ch/cache/ddmendpoints.json
 # path to storages JSON cache provided by shared filesystem
 storages_cvmfs: /cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_ddmendpoints.json
 # file name of local cache for the storages JSON

--- a/pilot/util/default.cfg
+++ b/pilot/util/default.cfg
@@ -149,7 +149,7 @@ queuedata_cvmfs: /cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json
 queuedata_cache: queuedata.json
 
 # URL for the PanDA queues API provided by Information system
-queues_url: https://atlas-cric.cern.ch/cache/schedconfig/pandaqueues.json
+queues_url: https://atlas-cric.cern.ch/cache/schedconfig/{pandaqueue}.json
 # path to PanDA queues JSON provided by shared filesystem
 queues_cvmfs: /cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json
 # file name of local cache for the PanDA queues JSON


### PR DESCRIPTION
By default use static JSON caches from CRIC instead of dynamic query for PandaQueues and DDMEndpoints.

unless custom urls are explicitly specified in the pilot config file

updates: few optimization applied to retrieve only corresponding JSON data for required PQ in case of single PQ request by `pilot.info`
