### PR TITLE
Fixed pandaserver url parsing and exception with --use-https=False

### DIFF
--- a/pilot/control/job.py
+++ b/pilot/control/job.py
@@ -451,16 +451,30 @@ def get_panda_server(url, port):
     :return: full URL (either from pilot options or from config file)
     """
 
-    if url.startswith('https://'):
-        url = url.replace('https://', '')
+    if url != '':
+        parsedurl = url.split('://')
+        scheme = None
+        loc = None
+        if len (parsedurl) == 2:
+            scheme = parsedurl[0]
+            loc = parsedurl[1]
+        else:
+            loc = parsedurl[0]
 
-    if url != '' and port != 0:
-        pandaserver = '%s:%s' % (url, port) if ":" not in url else url
+        parsedloc = loc.split(':')
+        loc = parsedloc[0]
+
+        # use port in url only if port argument is not provided
+        if port == 0 and len(parsedloc) == 2:
+            port = parsedloc[1]
+        # default scheme to https
+        if not scheme:
+            scheme = "https"
+        pandaserver = '%s://%s%s' % (scheme, loc, ':%s' % port if port else '')
     else:
         pandaserver = config.Pilot.pandaserver
-
-    if not pandaserver.startswith('http'):
-        pandaserver = 'https://' + pandaserver
+        if not pandaserver.startswith('http'):
+            pandaserver = 'https://' + pandaserver
 
     # add randomization for PanDA server
     default = 'pandaserver.cern.ch'

--- a/pilot/control/job.py
+++ b/pilot/control/job.py
@@ -455,7 +455,7 @@ def get_panda_server(url, port):
         parsedurl = url.split('://')
         scheme = None
         loc = None
-        if len (parsedurl) == 2:
+        if len(parsedurl) == 2:
             scheme = parsedurl[0]
             loc = parsedurl[1]
         else:

--- a/pilot/util/https.py
+++ b/pilot/util/https.py
@@ -37,7 +37,12 @@ from .constants import get_pilot_version
 import logging
 logger = logging.getLogger(__name__)
 
+# _ctx is used even with --use-https=False which skips https_setup() so we need to set initial values to avoid exceptions in get_curl_command.
 _ctx = collections.namedtuple('_ctx', 'ssl_context user_agent capath cacert')
+_ctx.ssl_context = None
+_ctx.user_agent = None
+_ctx.capath = None
+_ctx.cacert = None
 
 # anisyonk: public copy of `_ctx` to avoid logic break since ssl_context is reset inside the request() -- FIXME
 # anisyonk: public instance, should be properly initialized by `https_setup()`


### PR DESCRIPTION
* Fixed an issue with the pandaserver url parsing in job.py.
    * Whenever you specify both the http protocol in --url and a port as cli arguments ( `./pilot.py --url http://pandaserverurl -p 25080 ...`) then the port gets ignored and updateJob requests are sent to `http://pandaserverurl`. The reason was that the prefix `http://` is not removed and the conditional at [Line 458](https://github.com/PanDAWMS/pilot2/blob/029e013dec888eecadb34c485f8d7498fccd000f/pilot/control/job.py#L458) finds `:`and ignore the port.
  * Note that this was only affecting updateJob requests, getJob, UpdateEventRanges and other requests were using the correct URL.
* When using `--use-https=False` there is an exception occurring in [get_curl_command](https://github.com/PanDAWMS/pilot2/blob/029e013dec888eecadb34c485f8d7498fccd000f/pilot/util/https.py#L248) as it is still called and is using the `_ctx`object however `https_setup()` was never called to initialize the module.