### PR TITLE
Staging client should not use sites in downtime to try to get data.

### DIFF
--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -265,6 +265,7 @@ class StagingClient(object):
         if use_vp:
             query['schemes'] = ['root']
             query['rse_expression'] = 'istape=False\\type=SPECIAL'
+            query['ignore_availability'] = False
 
         # add signature lifetime for signed URL storages
         query.update(signature_lifetime=24 * 3600)  # note: default is otherwise 1h

--- a/pilot/api/data.py
+++ b/pilot/api/data.py
@@ -266,6 +266,7 @@ class StagingClient(object):
             query['schemes'] = ['root']
             query['rse_expression'] = 'istape=False\\type=SPECIAL'
             query['ignore_availability'] = False
+            query['sort'] = 'geoip'
 
         # add signature lifetime for signed URL storages
         query.update(signature_lifetime=24 * 3600)  # note: default is otherwise 1h


### PR DESCRIPTION
We found that pilot staging client tried to get data from Australia even the DDM endpoints there are in downtime.
Rucio list_replicas has a very strange default parameter that ignores availability. So I added it for VP jobs. 
 